### PR TITLE
sum up status over one hour

### DIFF
--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -29,6 +29,6 @@ groups:
     annotations:
       error: "Barman on {{ $labels.instance }} is not running"
   - alert: NoRemoteBarman
-    expr: sum(up{job="barman"})-sum(up{job="barman",instance="annex.montagu.dide.ic.ac.uk:5000"}) == 0
+    expr: sum(sum_over_time(up{job="barman"}[1h]))-sum(sum_over_time(up{job="barman",instance="annex.montagu.dide.ic.ac.uk:5000"}[1h])) == 0
     annotations:
       error: "No EC2 barman instances are reporting metrics"


### PR DESCRIPTION
`Up` status for barman jobs is now discontinuous with exactly one data point an hour, so using the `sum_over_time` aggregation to sum over the last hour should give us a continuous measure.