### PR TITLE
configure before a reload

### DIFF
--- a/config/configure.py
+++ b/config/configure.py
@@ -31,6 +31,5 @@ if __name__ == "__main__":
         "prometheus.template.yml",
         "prometheus/prometheus.yml",
         {"aws_access_key_id": vault.read_secret("secret/prometheus/aws_access_key_id"),
-         "aws_secret_key": vault.read_secret("secret/prometheus/aws_secret_key")},
-
+         "aws_secret_key": vault.read_secret("secret/prometheus/aws_secret_key")}
     )

--- a/reload
+++ b/reload
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Put secrets into configs
+./config/configure.py
+
 curl -X POST http://127.0.0.1:9093/-/reload
 
 curl -X POST http://127.0.0.1:9090/-/reload


### PR DESCRIPTION
`prometheus.yml` is created from a template by the `configure` script, so we need to run `configure` before reloading for changes to that config to take effect