### PR TITLE
i2244: Scrape machine metrics from EC2

### DIFF
--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -8,14 +8,14 @@ templates:
   - 'templates/*.tmpl'
 
 receivers:
-- name: 'slack'
-  slack_configs:
-  - channel: 'montagu-monitor'
-    username: '{{ if eq .Status "firing" }}prometheus-sad-bot{{ else }}prometheus-happy-bot{{ end }}'
-    send_resolved: true
-    color: '{{ if eq .Status "firing" }}warning{{ else }}good{{ end }}'
-    title: '{{ if eq .Status "firing" }}Problems detected{{ else }}Resolved{{ end }}'
-    text: '{{ template "slack-alert-text" .}}'
-    title_link: null
-    icon_emoji: '{{ if eq .Status "firing" }}:lightning:{{ else }}:sun_with_face:{{ end }}'
+  - name: 'slack'
+    slack_configs:
+      - channel: 'montagu-monitor'
+        username: '{{ if eq .Status "firing" }}prometheus-sad-bot{{ else }}prometheus-happy-bot{{ end }}'
+        send_resolved: true
+        color: '{{ if eq .Status "firing" }}warning{{ else }}good{{ end }}'
+        title: '{{ if eq .Status "firing" }}Problems detected{{ else }}Resolved{{ end }}'
+        text: '{{ template "slack-alert-text" .}}'
+        title_link: null
+        icon_emoji: '{{ if eq .Status "firing" }}:lightning:{{ else }}:sun_with_face:{{ end }}'
 

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -4,12 +4,15 @@ alerting:
         - targets: ['alertmanager:9093']
 
 scrape_configs:
+
   - job_name: 'aws'
     static_configs:
       - targets: ['aws_metrics:80']
+
   - job_name: 'barman'
     static_configs:
       - targets: ['annex.montagu.dide.ic.ac.uk:5000']
+
   - job_name: 'barman-remote'
     scrape_timeout: 60s
     scrape_interval: 2m
@@ -22,6 +25,17 @@ scrape_configs:
         target_label: __address__
         regex: (.+)
         replacement: <%text>$</%text>{1}:5000
+
+  - job_name: 'ec2-machine-metrics'
+    ec2_sd_configs:
+      - region: 'eu-west-2'
+        access_key: ${aws_access_key_id}
+        secret_key: ${aws_secret_key}
+    relabel_configs:
+      - source_labels: [__meta_ec2_public_dns_name]
+        target_label: __address__
+        regex: (.+)
+        replacement: <%text>$</%text>{1}:9100
 
 rule_files:
   - alert-rules.yml

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -1,27 +1,27 @@
 alerting:
   alertmanagers:
-  - static_configs:
-    - targets: ['alertmanager:9093']
+    - static_configs:
+        - targets: ['alertmanager:9093']
 
 scrape_configs:
-- job_name: 'aws'
-  static_configs:
-  - targets: ['aws_metrics:80']
-- job_name: 'barman'
-  static_configs:
-  - targets: ['annex.montagu.dide.ic.ac.uk:5000']
-- job_name: 'barman-remote'
-  scrape_timeout: 60s
-  scrape_interval: 2m
-  ec2_sd_configs:
-  - region: 'eu-west-2'
-    access_key: ${aws_access_key_id}
-    secret_key: ${aws_secret_key}
-  relabel_configs:
-  - source_labels: [__meta_ec2_public_dns_name]
-    target_label: __address__
-    regex: (.+)
-    replacement: <%text>$</%text>{1}:5000
+  - job_name: 'aws'
+    static_configs:
+      - targets: ['aws_metrics:80']
+  - job_name: 'barman'
+    static_configs:
+      - targets: ['annex.montagu.dide.ic.ac.uk:5000']
+  - job_name: 'barman-remote'
+    scrape_timeout: 60s
+    scrape_interval: 2m
+    ec2_sd_configs:
+      - region: 'eu-west-2'
+        access_key: ${aws_access_key_id}
+        secret_key: ${aws_secret_key}
+    relabel_configs:
+      - source_labels: [__meta_ec2_public_dns_name]
+        target_label: __address__
+        regex: (.+)
+        replacement: <%text>$</%text>{1}:5000
 
 rule_files:
-- alert-rules.yml
+  - alert-rules.yml

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -1,53 +1,53 @@
 groups:
-- name: aws
-  rules:
-  - alert: InstanceDown
-    expr: up{job="aws"} == 0
-    for: 5m
-    annotations:
-      error: "{{ $labels.instance }} is down"
-  - alert: BackupBucketMissing
-    expr: bucket_exists == 0
-    annotations:
-      error: "Required S3 bucket {{ $labels.bucket_id }} does not exist"
-  - alert: BackupStale
-    expr: bucket_files_time_since_last_modified_hours > 26
-    annotations:
-      error: "More than 26 hours have passed since any files were modified in bucket {{ $labels.bucket_id }}"
-  - alert: BackupShrunk
-    expr: delta(bucket_files_total_size_mb[24h]) < -1
-    annotations:
-      error: "Over the last 24 hours, the total amount of data stored in bucket {{ $labels.bucket_id }} has decreased by at least 1MB"
+  - name: aws
+    rules:
+      - alert: InstanceDown
+        expr: up{job="aws"} == 0
+        for: 5m
+        annotations:
+          error: "{{ $labels.instance }} is down"
+      - alert: BackupBucketMissing
+        expr: bucket_exists == 0
+        annotations:
+          error: "Required S3 bucket {{ $labels.bucket_id }} does not exist"
+      - alert: BackupStale
+        expr: bucket_files_time_since_last_modified_hours > 26
+        annotations:
+          error: "More than 26 hours have passed since any files were modified in bucket {{ $labels.bucket_id }}"
+      - alert: BackupShrunk
+        expr: delta(bucket_files_total_size_mb[24h]) < -1
+        annotations:
+          error: "Over the last 24 hours, the total amount of data stored in bucket {{ $labels.bucket_id }} has decreased by at least 1MB"
 
-- name: barman
-  rules:
-  - alert: BarmanDown
-    expr: up{job="barman"} == 0
-    for: 5m
-    annotations:
-      error: "{{ $labels.instance }} is down"
-  - alert: BarmanNotRunning
-    expr: barman_running{job="barman"} == 0
-    annotations:
-      error: "Barman on {{ $labels.instance }} is not running"
-  - alert: BarmanCheckFailed
-    expr: barman_ok{job="barman"} == 0
-    annotations:
-      error: "Barman check on {{ $labels.instance }} failed"
+  - name: barman
+    rules:
+      - alert: BarmanDown
+        expr: up{job="barman"} == 0
+        for: 5m
+        annotations:
+          error: "{{ $labels.instance }} is down"
+      - alert: BarmanNotRunning
+        expr: barman_running{job="barman"} == 0
+        annotations:
+          error: "Barman on {{ $labels.instance }} is not running"
+      - alert: BarmanCheckFailed
+        expr: barman_ok{job="barman"} == 0
+        annotations:
+          error: "Barman check on {{ $labels.instance }} failed"
 
-- name: barman-remote
-  rules:
-  - alert: NoRemoteBarman
-    expr: max(up{job="barman-remote"}) == 0 or absent({job="barman-remote"}) == 1
-    for: 5m
-    annotations:
-      error: "No EC2 barman instances are reporting metrics"
-  - alert: RemoteBarmanNotRunning
-    expr: barman_running{job="barman-remote"} == 0
-    annotations:
-      error: "Barman on {{ $labels.instance }} is not running"
-  - alert: RemoteBarmanCheckFailed
-    expr: barman_ok{job="barman-remote"} == 0
-    annotations:
-      error: "Barman check on {{ $labels.instance }} failed"
+  - name: barman-remote
+    rules:
+      - alert: NoRemoteBarman
+        expr: max(up{job="barman-remote"}) == 0 or absent({job="barman-remote"}) == 1
+        for: 5m
+        annotations:
+          error: "No EC2 barman instances are reporting metrics"
+      - alert: RemoteBarmanNotRunning
+        expr: barman_running{job="barman-remote"} == 0
+        annotations:
+          error: "Barman on {{ $labels.instance }} is not running"
+      - alert: RemoteBarmanCheckFailed
+        expr: barman_ok{job="barman-remote"} == 0
+        annotations:
+          error: "Barman check on {{ $labels.instance }} failed"
 


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-2244

This doesn't add any new rules yet, but it will hopefully give us some clues as to why the machine is falling over when we look back over the graphs. I've had a look through, and I think these two queries may be particularly helpful:

```
node_memory_MemAvailable_bytes
node_filefd_allocated
```

And in the future, we may well want rules on:

```
node_filesystem_free_bytes{mountpoint="/"}
node_filesystem_free_bytes{mountpoint="/mnt/data"}
```