### PR TITLE
remove shrunk backup alert

### DIFF
--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -14,10 +14,6 @@ groups:
         expr: bucket_files_time_since_last_modified_hours > 26
         annotations:
           error: "More than 26 hours have passed since any files were modified in bucket {{ $labels.bucket_id }}"
-      - alert: BackupShrunk
-        expr: delta(bucket_files_total_size_mb[24h]) < -1
-        annotations:
-          error: "Over the last 24 hours, the total amount of data stored in bucket {{ $labels.bucket_id }} has decreased by at least 1MB"
 
   - name: barman-shared
     rules:


### PR DESCRIPTION
This alert tells us nothing useful and pollutes the slack channel. Will be replaced longer term by https://vimc.myjetbrains.com/youtrack/issue/VIMC-2398 