### PR TITLE
Improve proxy metric alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ manager. These instances are configured by:
 To start the monitor and external metric exporters (see below) use:
 
 ```
-sudo pip3 install -r requirements.txt
+pip3 install -r requirements.txt --user
 ./run
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ and for reloading
 ./reload --dev
 ```
 
+To force alerts to fire just invert the rules in `prometheus/alert-rules.yml` temporarily, e.g. change a rule expression
+like
+
+`up{job="bb8"} == 0`
+
+to 
+
+`up{job="bb8"} == 1` 
+
+
 ## Deployment on support
 
 Connect as the `montagu` user on support (either by connecting with `ssh montagu@support.dide.ic.ac.uk` or by using `sudo su montagu`, then)

--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -3,6 +3,12 @@ global:
 
 route:
   receiver: 'slack'
+  repeat_interval: 4h
+  routes:
+    - match:
+        frequency: high
+      repeat_interval: 20m
+      receiver: 'slack'
 
 templates:
   - 'templates/*.tmpl'

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -7,7 +7,20 @@ scrape_configs:
 
   - job_name: 'proxy-metrics'
     static_configs:
-    - targets: ['montagu.vaccineimpact.org:9113', 'support.montagu.dide.ic.ac.uk:9113', 'support.montagu.dide.ic.ac.uk:9114']
+      - targets: ['montagu.vaccineimpact.org:9113', 'support.montagu.dide.ic.ac.uk:9113', 'support.montagu.dide.ic.ac.uk:9114']
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+        regex: (support)(.+)(9113)
+        replacement: 'UAT'
+      - source_labels: [__address__]
+        target_label: instance
+        regex: (.+)(9114)
+        replacement: 'Science'
+      - source_labels: [__address__]
+        target_label: instance
+        regex: (.+)(vaccineimpact)(.+)
+        replacement: 'Production'
 
   - job_name: 'aws'
     static_configs:

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -45,10 +45,12 @@ groups:
   - name: proxy
     rules:
       - alert: ProxyDown
-        expr: up{job="proxy-metrics"} == 0
+        labels:
+          frequency: "high"
+        expr: up{job="proxy-metrics"} == 1
         for: 5m
         annotations:
-          error: "Proxy metrics at {{ $labels.instance }} are down"
+          error: "Montagu on {{ $labels.instance }} is down"
 
   - name: barman-remote
     rules:

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -47,7 +47,7 @@ groups:
       - alert: ProxyDown
         labels:
           frequency: "high"
-        expr: up{job="proxy-metrics"} == 1
+        expr: up{job="proxy-metrics"} == 0
         for: 5m
         annotations:
           error: "Montagu on {{ $labels.instance }} is down"


### PR DESCRIPTION
- rewrite proxy instance labels to use human readable names: "UAT", "Science" etc
- make proxy down alerts fire more frequently than the others, we want to be alerted every 20mins if they remain down