### PR TITLE
VIMC-2887: Restructure log message

### DIFF
--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -20,7 +20,7 @@ groups:
       - alert: BarmanCacheStale
         expr: cache_out_of_date == 1
         annotations:
-          error: "Barman cached metrics are out of date on {{ $labels.instance }}"
+          error: "Barman cached metrics on {{ $labels.instance }} are out of date on"
       - alert: BarmanNotRunning
         expr: barman_running == 0
         annotations:

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -20,7 +20,7 @@ groups:
       - alert: BarmanCacheStale
         expr: cache_out_of_date == 1
         annotations:
-          error: "Barman cached metrics on {{ $labels.instance }} are out of date on"
+          error: "Barman cached metrics on {{ $labels.instance }} are out of date"
       - alert: BarmanNotRunning
         expr: barman_running == 0
         annotations:


### PR DESCRIPTION
This moves the message to the same format as other (THING on PLACE is PROBLEM)
but this is mostly so that the machine name does not get tangled up with
the markdown formatting when it comes through to slack