### PR TITLE
mrc-1845 add hint up rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ aws_configuration
 .idea/*
 config/alertmanager/alertmanager.yml
 config/prometheus/prometheus.yml
+config/prom2teams/config.ini
 config/__pycache__/*

--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -2,7 +2,7 @@ global:
   slack_api_url: https://hooks.slack.com/services/${slack_webhook}
 
 route:
-  receiver: 'slack'
+  receiver: 'Teams'
   repeat_interval: 4h
   routes:
     - match:
@@ -24,6 +24,9 @@ receivers:
         text: '{{ template "slack-alert-text" .}}'
         title_link: null
         icon_emoji: '{{ if eq .Status "firing" }}:lightning:{{ else }}:sun_with_face:{{ end }}'
+  - name: 'Teams'
+    webhook_configs:
+      - url: http://prom2teams:8089/v2/Connector
 
 inhibit_rules:
   - source_match:

--- a/config/config.template.ini
+++ b/config/config.template.ini
@@ -1,0 +1,9 @@
+[HTTP Server]
+Host: 0.0.0.0
+Port: 8089
+
+[Template]
+Path: /opt/prom2teams/alarm-template.j2
+
+[Microsoft Teams]
+Connector: ${connector}

--- a/config/configure.py
+++ b/config/configure.py
@@ -46,3 +46,8 @@ if __name__ == "__main__":
         {"aws_access_key_id": vault.read_secret("secret/prometheus/aws_access_key_id"),
          "aws_secret_key": vault.read_secret("secret/prometheus/aws_secret_key")}
     )
+    instantiate_config(
+        "config.template.ini",
+        "prom2teams/config.ini",
+        {"connector": vault.read_secret("secret/prometheus/teams_connector")}
+    )

--- a/config/prom2teams/alarm-template.j2
+++ b/config/prom2teams/alarm-template.j2
@@ -1,0 +1,25 @@
+{%- set
+  theme_colors = {
+    'resolved' : '2DC72D',
+    'firing' : '8C1A1A'
+  }
+-%}
+
+{
+    "@type": "MessageCard",
+    "@context": "http://schema.org/extensions",
+    "themeColor": "{% if status=='resolved' %} {{ theme_colors.resolved }} {% else %} {{ theme_colors.firing }} {% endif %}",
+    "summary": "{% if status=='resolved' %}(Resolved) {% endif %}{{ msg_text.name }}",
+    "sections": [{
+        "activityTitle": "<h1>{% if status=='resolved' %} &#x1F60E; Problem resolved {% else %} &#x26A1; Problem detected {% endif %}</h1>",
+        "text": "{% if status=='resolved' %}<strike>{{ msg_text.extra_annotations.error }}</strike> {% else %} {{ msg_text.extra_annotations.error }} {% endif %}",
+        "facts": [{% if msg_text.instance!='unknown' %}{
+            "name": "In host",
+            "value": "{{ msg_text.instance }}"
+        },{% endif %}{
+            "name": "Status",
+            "value": "{{ msg_text.status }}"
+        }],
+        "markdown": true
+    }]
+}

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -41,6 +41,11 @@ scrape_configs:
         regex: (.+)(vaccineimpact)(.+)
         replacement: 'Production'
 
+  - job_name: 'hint'
+    scheme: https
+    static_configs:
+      - targets: ['naomi.unaids.org']
+
   - job_name: 'aws'
     static_configs:
       - targets: ['aws_metrics:80']

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -62,6 +62,14 @@ groups:
         annotations:
           error: "OrderlyWeb on {{ $labels.instance }} is down"
 
+  - name: hint
+    rules:
+      - alert: HINTDown
+        expr: up{job="hint"} == 0
+        for: 5m
+        annotations:
+          error: "Naomi is down"
+
   - name: barman-remote
     rules:
       - alert: NoRemoteBarman

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,21 @@ services:
       - "${PWD}/config/alertmanager:/etc/alertmanager"
     ports:
       - "9093:9093"
+    depends_on:
+      - prom2teams
 
   aws_metrics:
     build: aws_metrics
     restart: always
     volumes:
       - "${PWD}/aws_metrics/config/volume:/root/.aws"
+
+  prom2teams:
+    image: idealista/prom2teams:3.1.0
+    volumes:
+      - "${PWD}/config/prom2teams/config.ini:/opt/prom2teams/config.ini"
+      - "${PWD}/config/prom2teams/alarm-template.j2:/opt/prom2teams/alarm-template.j2"
+    ports:
+      - "8089:8089"
+    restart: always
+


### PR DESCRIPTION
This is a non Montagu app - longer term, do we want a separate monitor instance, or do we move this over to being a general RESIDE instance?

This PR also moves the notifications over from Slack to Teams. It was simple to get this set up but took me *forever* to customise the message to something reasonably nice looking in Teams! Predictably tragic emoji support :disappointed: 

I've set this up to go to a new channel `reside-monitor`. It's been running from my laptop so you can see the output in that channel. We shouldn't deploy this until HINT is deployed with a metrics endpoint, otherwise the `HintDown` alert will keep firing. HINT PR here: https://github.com/mrc-ide/hint/pull/368