### PR TITLE
vimc-4530: Add monitoring of buildkite agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config/alertmanager/alertmanager.yml
 config/prometheus/prometheus.yml
 config/prom2teams/config.ini
 config/__pycache__/*
+config/buildkite.env

--- a/config/configure.py
+++ b/config/configure.py
@@ -51,3 +51,7 @@ if __name__ == "__main__":
         "prom2teams/config.ini",
         {"connector": vault.read_secret("secret/prometheus/teams_connector")}
     )
+    with open("buildkite.env", 'w') as f:
+        f.write("BUIDLKITE_AGENT_TOKEN={}".format( \
+            vault.read_secret("secret/buildkite/agent", "token")))
+

--- a/config/configure.py
+++ b/config/configure.py
@@ -52,6 +52,6 @@ if __name__ == "__main__":
         {"connector": vault.read_secret("secret/prometheus/teams_connector")}
     )
     with open("buildkite.env", 'w') as f:
-        f.write("BUIDLKITE_AGENT_TOKEN={}".format( \
+        f.write("BUILDKITE_AGENT_TOKEN={}".format( \
             vault.read_secret("secret/buildkite/agent", "token")))
 

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -94,5 +94,9 @@ scrape_configs:
         regex: (.+)
         replacement: <%text>$</%text>{1}:9100
 
+  - job_name: 'buildkite-metrics'
+    static_configs:
+    - targets: ['buildkite_metrics:8080']
+
 rule_files:
   - alert-rules.yml

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -142,3 +142,15 @@ groups:
         annotations:
           error: "Number of targets backed up to Starport has shrunk in the last hour"
 
+  - name: buildkite-metrics
+    rules:
+      - alert: BuildkiteMetricsDown
+        expr: up{job="buildkite-metrics"} == 0
+        for: 5m
+        annotations:
+          error: "buildkite-agent-metrics is down"
+      - alert: AgentsDown
+        expr: buildkite_total_total_agent_count{job="buildkite-metrics"} < 10
+        for: 5m
+        annotations:
+          error: "Buildkite has fewer than 10 agents"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   buildkite_metrics:
     image: reside/buildkite-agent-metrics
     restart: always
-    env_file: buildkite.env
+    env_file: config/buildkite.env
     command:
-      - '-backend prometheus'
-      - '-interval 30s'
+      - '-backend=prometheus'
+      - '-interval=30s'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,3 +44,10 @@ services:
       - "8089:8089"
     restart: always
 
+  buildkite_metrics:
+    image: reside/buildkite-agent-metrics
+    restart: always
+    command:
+      - '-token ${BUILDKITE_AGENT_TOKEN}'
+      - '-backend prometheus'
+      - '-interval 30s'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "9090:9090"
     volumes:
       - "${PWD}/config/prometheus:/etc/prometheus"
-    depends_on: 
+    depends_on:
       - alertmanager
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -47,7 +47,7 @@ services:
   buildkite_metrics:
     image: reside/buildkite-agent-metrics
     restart: always
+    env_file: buildkite.env
     command:
-      - '-token ${BUILDKITE_AGENT_TOKEN}'
       - '-backend prometheus'
       - '-interval 30s'


### PR DESCRIPTION
This uses https://github.com/buildkite/buildkite-agent-metrics 

This just checks that there are more than 10 running, but gives us the ability to check some more detailed metrics see https://github.com/buildkite/buildkite-agent-metrics#metrics

As part of this I have added docker build from buildkite-agent-metrics Dockerfile which is here https://github.com/reside-ic/buildkite-agent-metrics it looks like they don't build an official one https://github.com/buildkite/buildkite-agent-metrics/issues/51 and other ones are out of date. I think I should probably set this to run on a schedule to keep it up to date, every month? I feel like this is a bit fragile to the structure of that repo changing so would be keen to hear alternatives