### PR TITLE
vimc-7144: Move alerts back onto slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ manager. These instances are configured by:
 To start the monitor and external metric exporters (see below) use:
 
 ```
+git submodule init
+git submodule update
 pip3 install -r requirements.txt --user
 ./run
 ```

--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -5,12 +5,12 @@ route:
   receiver: 'slack'
   repeat_interval: 4h
   routes:
-    - match:
-        frequency: high
+    - matchers:
+        - frequency = high
       repeat_interval: 20m
       receiver: 'slack'
-    - match:
-        frequency: low
+    - matchers:
+        - frequency = low
       repeat_interval: 24h
       receiver: 'slack'
 

--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -1,14 +1,14 @@
 global:
-  slack_api_url: https://hooks.slack.com/services/${slack_webhook}
+  slack_api_url: https://slack.com/api/chat.postMessage
 
 route:
-  receiver: 'Teams'
-  repeat_interval: 4h
+  receiver: 'slack'
+  repeat_interval: 4m
   routes:
     - match:
         frequency: high
       repeat_interval: 20m
-      receiver: 'Teams'
+      receiver: 'slack'
 
 templates:
   - 'templates/*.tmpl'
@@ -24,9 +24,10 @@ receivers:
         text: '{{ template "slack-alert-text" .}}'
         title_link: null
         icon_emoji: '{{ if eq .Status "firing" }}:lightning:{{ else }}:sun_with_face:{{ end }}'
-  - name: 'Teams'
-    webhook_configs:
-      - url: http://prom2teams:8089/v2/Connector
+        http_config:
+          authorization:
+            type: Bearer
+            credentials: ${slack_oauth_token}
 
 inhibit_rules:
   - source_match:

--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -35,6 +35,10 @@ receivers:
         color: '{{ if eq .Status "firing" }}warning{{ else }}good{{ end }}'
         title: '{{ if eq .Status "firing" }}Problems detected{{ else }}Resolved{{ end }}'
         text: '{{ template "slack-alert-text" .}}'
+        actions:
+          - text: 'Silence'
+            type: button
+            url: 'https://mrc-ide.myjetbrains.com/youtrack/articles/RESIDE-A-22/Monitoring#silence-an-alert'
         title_link: null
         icon_emoji: '{{ if eq .Status "firing" }}:lightning:{{ else }}:sun_with_face:{{ end }}'
         http_config:
@@ -50,6 +54,10 @@ receivers:
         color: '{{ if eq .Status "firing" }}warning{{ else }}good{{ end }}'
         title: '{{ if eq .Status "firing" }}Problems detected{{ else }}Resolved{{ end }}'
         text: '{{ template "slack-alert-text" .}}'
+        actions:
+          - text: 'Silence'
+            type: button
+            url: 'https://mrc-ide.myjetbrains.com/youtrack/articles/RESIDE-A-22/Monitoring#silence-an-alert'
         title_link: null
         icon_emoji: '{{ if eq .Status "firing" }}:lightning:{{ else }}:sun_with_face:{{ end }}'
         http_config:

--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -3,11 +3,15 @@ global:
 
 route:
   receiver: 'slack'
-  repeat_interval: 4m
+  repeat_interval: 4h
   routes:
     - match:
         frequency: high
       repeat_interval: 20m
+      receiver: 'slack'
+    - match:
+        frequency: low
+      repeat_interval: 24h
       receiver: 'slack'
 
 templates:

--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -30,13 +30,12 @@ receivers:
             credentials: ${slack_oauth_token}
 
 inhibit_rules:
-  - source_match:
-      alertname: NoRemoteBarman
-    target_match:
-      job: barman-remote
-    equal:
-  - source_match:
-      alertname: BarmanDown
-    target_match:
+  - source_matchers:
+      - alertname = NoRemoteBarman
+    target_matchers:
+      - job = barman-remote
+  - source_matchers:
+      - alertname = BarmanDown
+    target_matchers:
     equal:
     - instance

--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -2,25 +2,49 @@ global:
   slack_api_url: https://slack.com/api/chat.postMessage
 
 route:
-  receiver: 'slack'
+  receiver: 'slack-default'
   repeat_interval: 4h
   routes:
     - matchers:
+        - project = hint
         - frequency = high
       repeat_interval: 20m
-      receiver: 'slack'
+      receiver: 'slack-hint'
+    - matchers:
+        - project = hint
+      repeat_interval: 4h
+      receiver: 'slack-hint'
+    - matchers:
+        - frequency = high
+      repeat_interval: 20m
+      receiver: 'slack-default'
     - matchers:
         - frequency = low
       repeat_interval: 24h
-      receiver: 'slack'
+      receiver: 'slack-default'
 
 templates:
   - 'templates/*.tmpl'
 
 receivers:
-  - name: 'slack'
+  - name: 'slack-default'
     slack_configs:
-      - channel: ${slack_channel}
+      - channel: ${slack_default_channel}
+        username: '{{ if eq .Status "firing" }}prometheus-sad-bot{{ else }}prometheus-happy-bot{{ end }}'
+        send_resolved: true
+        color: '{{ if eq .Status "firing" }}warning{{ else }}good{{ end }}'
+        title: '{{ if eq .Status "firing" }}Problems detected{{ else }}Resolved{{ end }}'
+        text: '{{ template "slack-alert-text" .}}'
+        title_link: null
+        icon_emoji: '{{ if eq .Status "firing" }}:lightning:{{ else }}:sun_with_face:{{ end }}'
+        http_config:
+          authorization:
+            type: Bearer
+            credentials: ${slack_oauth_token}
+
+  - name: 'slack-hint'
+    slack_configs:
+      - channel: ${slack_hint_channel}
         username: '{{ if eq .Status "firing" }}prometheus-sad-bot{{ else }}prometheus-happy-bot{{ end }}'
         send_resolved: true
         color: '{{ if eq .Status "firing" }}warning{{ else }}good{{ end }}'

--- a/config/configure.py
+++ b/config/configure.py
@@ -40,7 +40,8 @@ if __name__ == "__main__":
         "alertmanager.template.yml",
         "alertmanager/alertmanager.yml",
         {"slack_oauth_token": vault.read_secret(slack_oauth_token),
-         "slack_channel": slack_channel}
+         "slack_default_channel": slack_default_channel,
+         "slack_hint_channel": slack_hint_channel}
     )
     instantiate_config(
         "prometheus.template.yml",

--- a/config/configure.py
+++ b/config/configure.py
@@ -27,9 +27,11 @@ if __name__ == "__main__":
 
     args = docopt(__doc__)
     if args["--dev"]:
-        slack_channel = "monitor-test"
+        slack_default_channel = "monitor-test"
+        slack_hint_channel = "monitor-test"
     else:
-        slack_channel = "montagu-monitor"
+        slack_default_channel = "montagu-monitor"
+        slack_hint_channel = "hint-monitor"
 
     slack_oauth_token = "secret/vimc/slack/oauth-token"
 

--- a/config/configure.py
+++ b/config/configure.py
@@ -27,17 +27,17 @@ if __name__ == "__main__":
 
     args = docopt(__doc__)
     if args["--dev"]:
-        slack_webhook_key = "secret/vimc/slack/test-webhook"
-        slack_channel = "montagu-test"
+        slack_channel = "monitor-test"
     else:
-        slack_webhook_key = "secret/vimc/slack/monitor-webhook"
         slack_channel = "montagu-monitor"
+
+    slack_oauth_token = "secret/vimc/slack/oauth-token"
 
     Path('alertmanager').mkdir(exist_ok=True)
     instantiate_config(
         "alertmanager.template.yml",
         "alertmanager/alertmanager.yml",
-        {"slack_webhook": vault.read_secret(slack_webhook_key),
+        {"slack_oauth_token": vault.read_secret(slack_oauth_token),
          "slack_channel": slack_channel}
     )
     instantiate_config(
@@ -45,11 +45,6 @@ if __name__ == "__main__":
         "prometheus/prometheus.yml",
         {"aws_access_key_id": vault.read_secret("secret/vimc/prometheus/aws_access_key_id"),
          "aws_secret_key": vault.read_secret("secret/vimc/prometheus/aws_secret_key")}
-    )
-    instantiate_config(
-        "config.template.ini",
-        "prom2teams/config.ini",
-        {"connector": vault.read_secret("secret/vimc/prometheus/teams_connector")}
     )
     with open("buildkite.env", 'w') as f:
         f.write("BUILDKITE_AGENT_TOKEN={}".format( \

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -50,21 +50,29 @@ scrape_configs:
     scheme: https
     static_configs:
       - targets: ['naomi.unaids.org']
+        labels:
+          channel: hint-monitor
 
   - job_name: 'hint-dev'
     scheme: https
     static_configs:
       - targets: ['naomi-dev.dide.ic.ac.uk']
+        labels:
+          channel: hint-monitor
 
   - job_name: 'hint-staging'
     scheme: https
     static_configs:
       - targets: ['naomi-staging.dide.ic.ac.uk']
+        labels:
+          channel: hint-monitor
 
   - job_name: 'hint-preview'
     scheme: https
     static_configs:
       - targets: ['naomi-preview.dide.ic.ac.uk']
+        labels:
+          channel: hint-monitor
 
   - job_name: 'aws'
     static_configs:
@@ -106,6 +114,8 @@ scrape_configs:
   - job_name: 'hint-machine-metrics'
     static_configs:
       - targets: ['naomi.dide.ic.ac.uk:9100', 'wpia-naomi-preview.dide.ic.ac.uk:9100', 'wpia-naomi-dev.dide.ic.ac.uk:9100', 'wpia-naomi-staging.dide.ic.ac.uk:9100']
+        labels:
+          channel: hint-monitor
     relabel_configs:
       - source_labels: [__address__]
         target_label: instance

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -51,28 +51,29 @@ scrape_configs:
     static_configs:
       - targets: ['naomi.unaids.org']
         labels:
-          channel: hint-monitor
+          project: hint
+          frequency: high
 
   - job_name: 'hint-dev'
     scheme: https
     static_configs:
       - targets: ['naomi-dev.dide.ic.ac.uk']
         labels:
-          channel: hint-monitor
+          project: hint
 
   - job_name: 'hint-staging'
     scheme: https
     static_configs:
       - targets: ['naomi-staging.dide.ic.ac.uk']
         labels:
-          channel: hint-monitor
+          project: hint
 
   - job_name: 'hint-preview'
     scheme: https
     static_configs:
       - targets: ['naomi-preview.dide.ic.ac.uk']
         labels:
-          channel: hint-monitor
+          project: hint
 
   - job_name: 'aws'
     static_configs:
@@ -113,9 +114,13 @@ scrape_configs:
 
   - job_name: 'hint-machine-metrics'
     static_configs:
-      - targets: ['naomi.dide.ic.ac.uk:9100', 'wpia-naomi-preview.dide.ic.ac.uk:9100', 'wpia-naomi-dev.dide.ic.ac.uk:9100', 'wpia-naomi-staging.dide.ic.ac.uk:9100']
+      - targets: ['naomi.dide.ic.ac.uk:9100']
         labels:
-          channel: hint-monitor
+          project: hint
+          frequency: high
+      - targets: [ 'wpia-naomi-preview.dide.ic.ac.uk:9100', 'wpia-naomi-dev.dide.ic.ac.uk:9100', 'wpia-naomi-staging.dide.ic.ac.uk:9100' ]
+        labels:
+          project: hint
     relabel_configs:
       - source_labels: [__address__]
         target_label: instance

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -26,7 +26,12 @@ scrape_configs:
     metrics_path: /reports/metrics
     scheme: https
     static_configs:
-      - targets: ['montagu.vaccineimpact.org', 'uat.montagu.dide.ic.ac.uk', 'science.montagu.dide.ic.ac.uk']
+      - targets: ['montagu.vaccineimpact.org', 'science.montagu.dide.ic.ac.uk']
+        labels:
+          frequency: high
+      - targets: ['uat.montagu.dide.ic.ac.uk']
+        labels:
+          frequency: low
     relabel_configs:
       - source_labels: [__address__]
         target_label: instance

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -55,8 +55,6 @@ groups:
   - name: orderly-web
     rules:
       - alert: OrderlyWebDown
-        labels:
-          frequency: "high"
         expr: up{job="orderly-web"} == 0
         for: 5m
         annotations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,23 +26,12 @@ services:
       - "${PWD}/config/alertmanager:/etc/alertmanager"
     ports:
       - "9093:9093"
-    depends_on:
-      - prom2teams
 
   aws_metrics:
     build: aws_metrics
     restart: always
     volumes:
       - "${PWD}/aws_metrics/config/volume:/root/.aws"
-
-  prom2teams:
-    image: idealista/prom2teams:3.1.0
-    volumes:
-      - "${PWD}/config/prom2teams/config.ini:/opt/prom2teams/config.ini"
-      - "${PWD}/config/prom2teams/alarm-template.j2:/opt/prom2teams/alarm-template.j2"
-    ports:
-      - "8089:8089"
-    restart: always
 
   buildkite_metrics:
     image: reside/buildkite-agent-metrics


### PR DESCRIPTION
This PR handles a few small things
* Move alerts back to slack from teams (I haven't removed all the teams config as I suppose we might want it later, but this will no longer post to teams after this change).
* Updates the slack integration to now use `postMessage` instead of the webhooks. Looks like webhooks are not only per channel, cannot define a webhook which can access multiple channels. So instead gone for the approach of using a bot oauth token to authenticate and then use `postMessage` API route
* Added a button into the post "Silence" which will open a link to view docs on how to silence an alert
* Reduced the frequency of OW on UAT alerts to every 24 hours
* Added separate alerting for hint. hint alerts will go to `hint-monitor` channel and all other alerts to `montagu-monitor`

The setup for separating the hint alerts is a little fiddly and not very extensible. I tried setting the channel using a `label` from within the `slack_configs` but I realise at the level of the `slack_configs` we are working with [data](https://prometheus.io/docs/alerting/latest/notifications/#data) related to all the alerts which we are notifying. So if we have alerts for hint and montagu firing at the same time if we want these to go to different channels we need to split them before this step i.e. during the routing. So this makes a bit of a proliferation of routes, and indeed if we want to alert for another project we'll have to add more. Which isn't fun... happy to hear suggestions if any other bright ideas about how to do that?