### PR TITLE
reside-362: Add grafana to monitoring setup and alert on disk usage

### DIFF
--- a/config/configure.py
+++ b/config/configure.py
@@ -20,6 +20,34 @@ def instantiate_config(template_path, target_path, values):
         f.write(template.render(**values))
 
 
+# Not amazing that we have to write this here duplicating the IP
+# setup done on the hyperv machine. But this needs to be defined
+# somewhere as we can't use data from after the scraping in the
+# rename config. And having this here is a bit more explicit than
+# having the renaming done in grafana
+node_exporter_metrics_targets = {
+    "montagu.vaccineimpact.org:9100": "montagu prod",
+    "wpia-annex2.montagu.dide.ic.ac.uk:9100": "annex",
+    "14.0.0.2": "reside-bk1",
+    "14.0.0.3": "reside-bk2",
+    "14.0.0.4": "reside-bk3",
+    "14.0.0.5": "reside-bk4",
+    "14.0.0.6": "reside-bk5",
+    "14.0.0.7": "reside-bk6",
+    "14.0.0.8": "reside-bk7",
+    "14.0.0.9": "reside-bk8",
+    "14.0.0.10": "reside-deploy1",
+    "14.0.0.11": "reside-bk-browser-test1",
+    "14.0.0.12": "reside-bk-multicore1",
+    "14.0.0.13": "reside-bk-multicore2",
+    "14.0.0.14": "reside-bk-multicore3"
+}
+
+
+def relabel_config(ip, target):
+    return ['- targets: ["{}"]'.format(ip), '  labels: ', '    instance: "{}"'.format(target)]
+
+
 if __name__ == "__main__":
     # Set working directory to this script's dir
     chdir(dirname(realpath(__file__)))
@@ -35,6 +63,10 @@ if __name__ == "__main__":
 
     slack_oauth_token = "secret/vimc/slack/oauth-token"
 
+    metrics_targets = []
+    for ip, target in node_exporter_metrics_targets.items():
+        metrics_targets += relabel_config(ip, target)
+
     Path('alertmanager').mkdir(exist_ok=True)
     instantiate_config(
         "alertmanager.template.yml",
@@ -47,7 +79,8 @@ if __name__ == "__main__":
         "prometheus.template.yml",
         "prometheus/prometheus.yml",
         {"aws_access_key_id": vault.read_secret("secret/vimc/prometheus/aws_access_key_id"),
-         "aws_secret_key": vault.read_secret("secret/vimc/prometheus/aws_secret_key")}
+         "aws_secret_key": vault.read_secret("secret/vimc/prometheus/aws_secret_key"),
+         "metrics_targets": "\n      ".join(metrics_targets)}
     )
     with open("buildkite.env", 'w') as f:
         f.write("BUILDKITE_AGENT_TOKEN={}".format( \

--- a/config/configure.py
+++ b/config/configure.py
@@ -28,19 +28,19 @@ def instantiate_config(template_path, target_path, values):
 node_exporter_metrics_targets = {
     "montagu.vaccineimpact.org:9100": "montagu prod",
     "wpia-annex2.montagu.dide.ic.ac.uk:9100": "annex",
-    "14.0.0.2": "reside-bk1",
-    "14.0.0.3": "reside-bk2",
-    "14.0.0.4": "reside-bk3",
-    "14.0.0.5": "reside-bk4",
-    "14.0.0.6": "reside-bk5",
-    "14.0.0.7": "reside-bk6",
-    "14.0.0.8": "reside-bk7",
-    "14.0.0.9": "reside-bk8",
-    "14.0.0.10": "reside-deploy1",
-    "14.0.0.11": "reside-bk-browser-test1",
-    "14.0.0.12": "reside-bk-multicore1",
-    "14.0.0.13": "reside-bk-multicore2",
-    "14.0.0.14": "reside-bk-multicore3"
+    "14.0.0.2:9100": "reside-bk1",
+    "14.0.0.3:9100": "reside-bk2",
+    "14.0.0.4:9100": "reside-bk3",
+    "14.0.0.5:9100": "reside-bk4",
+    "14.0.0.6:9100": "reside-bk5",
+    "14.0.0.7:9100": "reside-bk6",
+    "14.0.0.8:9100": "reside-bk7",
+    "14.0.0.9:9100": "reside-bk8",
+    "14.0.0.10:9100": "reside-deploy1",
+    "14.0.0.11:9100": "reside-bk-browser-test1",
+    "14.0.0.12:9100": "reside-bk-multicore1",
+    "14.0.0.13:9100": "reside-bk-multicore2",
+    "14.0.0.14:9100": "reside-bk-multicore3"
 }
 
 

--- a/config/grafana/datasource.yml
+++ b/config/grafana/datasource.yml
@@ -18,7 +18,7 @@ datasources:
     # proxy or direct (Server or Browser in the UI).
     # Some data sources are incompatible with any setting
     # but proxy (Server).
-    access: direct
+    access: proxy
     # <int> Sets the organization id. Defaults to orgId 1.
     orgId: 1
     # <string> Sets a custom UID to reference this
@@ -27,7 +27,7 @@ datasources:
     uid: my_unique_uid
     # <string> Sets the data source's URL, including the
     # port.
-    url: prometheus:9090
+    url: http://prometheus:9090
     # <string> Sets the database user, if necessary.
     user:
     # <string> Sets the database name, if necessary.

--- a/config/grafana/datasource.yml
+++ b/config/grafana/datasource.yml
@@ -1,0 +1,71 @@
+# Configuration file version
+apiVersion: 1
+
+# List of data sources to delete from the database.
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+
+# List of data sources to insert/update depending on what's
+# available in the database.
+datasources:
+  # <string, required> Sets the name you use to refer to
+  # the data source in panels and queries.
+  - name: Prometheus
+    # <string, required> Sets the data source type.
+    type: prometheus
+    # <string, required> Sets the access mode, either
+    # proxy or direct (Server or Browser in the UI).
+    # Some data sources are incompatible with any setting
+    # but proxy (Server).
+    access: proxy
+    # <int> Sets the organization id. Defaults to orgId 1.
+    orgId: 1
+    # <string> Sets a custom UID to reference this
+    # data source in other parts of the configuration.
+    # If not specified, Grafana generates one.
+    uid: my_unique_uid
+    # <string> Sets the data source's URL, including the
+    # port.
+    url: monitor_prometheus_1:9090
+    # <string> Sets the database user, if necessary.
+    user:
+    # <string> Sets the database name, if necessary.
+    database:
+    # <bool> Enables basic authorization.
+    basicAuth:
+    # <string> Sets the basic authorization username.
+    basicAuthUser:
+    # <bool> Enables credential headers.
+    withCredentials:
+    # <bool> Toggles whether the data source is pre-selected
+    # for new panels. You can set only one default
+    # data source per organization.
+    isDefault:
+    # <map> Fields to convert to JSON and store in jsonData.
+    jsonData:
+      # <string> Defines the Graphite service's version.
+      graphiteVersion: '1.1'
+      # <bool> Enables TLS authentication using a client
+      # certificate configured in secureJsonData.
+      tlsAuth: false
+      # <bool> Enables TLS authentication using a CA
+      # certificate.
+      tlsAuthWithCACert: false
+    # <map> Fields to encrypt before storing in jsonData.
+    secureJsonData:
+      # <string> Defines the CA cert, client cert, and
+      # client key for encrypted authentication.
+      tlsCACert: '...'
+      tlsClientCert: '...'
+      tlsClientKey: '...'
+      # <string> Sets the database password, if necessary.
+      password:
+      # <string> Sets the basic authorization password.
+      basicAuthPassword:
+    # <int> Sets the version. Used to compare versions when
+    # updating. Ignored when creating a new data source.
+    version: 1
+    # <bool> Allows users to edit data sources from the
+    # Grafana UI.
+    editable: false

--- a/config/grafana/datasource.yml
+++ b/config/grafana/datasource.yml
@@ -18,7 +18,7 @@ datasources:
     # proxy or direct (Server or Browser in the UI).
     # Some data sources are incompatible with any setting
     # but proxy (Server).
-    access: proxy
+    access: direct
     # <int> Sets the organization id. Defaults to orgId 1.
     orgId: 1
     # <string> Sets a custom UID to reference this
@@ -27,7 +27,7 @@ datasources:
     uid: my_unique_uid
     # <string> Sets the data source's URL, including the
     # port.
-    url: monitor_prometheus_1:9090
+    url: prometheus:9090
     # <string> Sets the database user, if necessary.
     user:
     # <string> Sets the database name, if necessary.

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -121,7 +121,11 @@ scrape_configs:
       - targets: ['wpia-naomi-preview.dide.ic.ac.uk:9100', 'wpia-naomi-dev.dide.ic.ac.uk:9100', 'wpia-naomi-staging.dide.ic.ac.uk:9100']
         labels:
           project: hint
-      - targets: ['montagu.vaccineimpact.org:9100', 'wpia-annex2.montagu.dide.ic.ac.uk:9100']
+      - targets: [
+        'montagu.vaccineimpact.org:9100',
+        'wpia-annex2.montagu.dide.ic.ac.uk:9100',
+        '14.0.0.2:9100'
+      ]
     relabel_configs:
       - source_labels: [__address__]
         target_label: instance

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -126,19 +126,19 @@ scrape_configs:
       - source_labels: [__address__]
         target_label: instance
         regex: (naomi)(.+)
-        replacement: 'production'
+        replacement: 'hint production'
       - source_labels: [__address__]
         target_label: instance
         regex: (wpia-naomi-preview)(.+)
-        replacement: 'preview'
+        replacement: 'hint preview'
       - source_labels: [__address__]
         target_label: instance
         regex: (wpia-naomi-dev)(.+)
-        replacement: 'dev'
+        replacement: 'hint dev'
       - source_labels: [__address__]
         target_label: instance
         regex: (wpia-naomi-staging)(.+)
-        replacement: 'staging'
+        replacement: 'hint staging'
       - source_labels: [__address__]
         target_label: instance
         regex: (montagu.vaccineimpact)(.+)

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -121,11 +121,7 @@ scrape_configs:
       - targets: ['wpia-naomi-preview.dide.ic.ac.uk:9100', 'wpia-naomi-dev.dide.ic.ac.uk:9100', 'wpia-naomi-staging.dide.ic.ac.uk:9100']
         labels:
           project: hint
-      - targets: [
-        'montagu.vaccineimpact.org:9100',
-        'wpia-annex2.montagu.dide.ic.ac.uk:9100',
-        '14.0.0.2:9100'
-      ]
+      ${metrics_targets}
     relabel_configs:
       - source_labels: [__address__]
         target_label: instance

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -112,15 +112,16 @@ scrape_configs:
     static_configs:
     - targets: ['buildkite_metrics:8080']
 
-  - job_name: 'hint-machine-metrics'
+  - job_name: 'machine-metrics'
     static_configs:
       - targets: ['naomi.dide.ic.ac.uk:9100']
         labels:
           project: hint
           frequency: high
-      - targets: [ 'wpia-naomi-preview.dide.ic.ac.uk:9100', 'wpia-naomi-dev.dide.ic.ac.uk:9100', 'wpia-naomi-staging.dide.ic.ac.uk:9100' ]
+      - targets: ['wpia-naomi-preview.dide.ic.ac.uk:9100', 'wpia-naomi-dev.dide.ic.ac.uk:9100', 'wpia-naomi-staging.dide.ic.ac.uk:9100']
         labels:
           project: hint
+      - targets: ['montagu.vaccineimpact.org:9100', 'wpia-annex2.montagu.dide.ic.ac.uk:9100']
     relabel_configs:
       - source_labels: [__address__]
         target_label: instance
@@ -138,6 +139,15 @@ scrape_configs:
         target_label: instance
         regex: (wpia-naomi-staging)(.+)
         replacement: 'staging'
+      - source_labels: [__address__]
+        target_label: instance
+        regex: (montagu.vaccineimpact)(.+)
+        replacement: 'montagu production'
+      - source_labels: [ __address__ ]
+        target_label: instance
+        regex: (wpia-annex2)(.+)
+        replacement: 'montagu annex'
+
 
 rule_files:
   - alert-rules.yml

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -146,3 +146,16 @@ groups:
         for: 5m
         annotations:
           error: "Buildkite ncov CDI agent is down"
+
+  - name: disk-usage
+    rules:
+      - alert: DiskNearlyFull
+        expr: (100 - (avg_over_time(node_filesystem_avail_bytes{job="machine-metrics"}[1h]) * 100) / avg_over_time(node_filesystem_size_bytes{job="machine-metrics"}[1h])) > 80
+        for: 5m
+        annotations:
+          error: "Disk usage over 80%"
+      - alert: DiskWillFillIn2Weeks
+        expr: predict_linear(node_filesystem_free{job="machine-metrics"}[1h], 14 * 24 * 3600) < 0
+        for: 5m
+        annotations:
+          error: "Disk will be full in 2 weeks"

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -153,9 +153,9 @@ groups:
         expr: (100 - (avg_over_time(node_filesystem_avail_bytes{job="machine-metrics"}[1h]) * 100) / avg_over_time(node_filesystem_size_bytes{job="machine-metrics"}[1h])) > 80
         for: 5m
         annotations:
-          error: "Disk usage over 80%"
+          error: "{{ $labels.instance }} disk usage over 80%"
       - alert: DiskWillFillIn2Weeks
         expr: predict_linear(node_filesystem_free{job="machine-metrics"}[1h], 14 * 24 * 3600) < 0
         for: 5m
         annotations:
-          error: "Disk will be full in 2 weeks"
+          error: "{{ $labels.instance }} will be full in 2 weeks"

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -10,10 +10,6 @@ groups:
         expr: bucket_exists == 0
         annotations:
           error: "Required S3 bucket {{ $labels.bucket_id }} does not exist"
-      - alert: BackupStale
-        expr: bucket_files_time_since_last_modified_hours > 26
-        annotations:
-          error: "More than 26 hours have passed since any files were modified in bucket {{ $labels.bucket_id }}"
 
   - name: barman-shared
     rules:
@@ -112,14 +108,6 @@ groups:
         annotations:
           error: "Naomi-preview has fewer than 2 workers"
 
-  - name: barman-remote
-    rules:
-      - alert: NoRemoteBarman
-        expr: max(up{job="barman-remote"}) == 0 or absent({job="barman-remote"}) == 1
-        for: 5m
-        annotations:
-          error: "No EC2 barman instances are reporting metrics"
-
   - name: bb8
     rules:
       - alert: bb8Down
@@ -131,10 +119,6 @@ groups:
         expr: time_since_last_backup_hours > 26
         annotations:
           error: "More than 26 hours have passed since bb8 backup of {{ $labels.target_id }}"
-      - alert: MetadataCorrupted
-        expr: metadata_present == 0
-        annotations:
-          error: "bb8 metadata missing for {{ $labels.target_id }}"
       - alert: TargetsShrunk
         expr: delta(number_of_targets[1h]) < 0
         annotations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "9090:9090"
     volumes:
       - "${PWD}/config/prometheus:/etc/prometheus"
+      - prometheus-storage:/prometheus
     depends_on:
       - alertmanager
     command:
@@ -56,3 +57,4 @@ services:
 
 volumes:
   grafana-storage: {}
+  prometheus-stoage: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,4 +57,4 @@ services:
 
 volumes:
   grafana-storage: {}
-  prometheus-stoage: {}
+  prometheus-storage: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,3 +40,19 @@ services:
     command:
       - '-backend=prometheus'
       - '-interval=30s'
+
+  grafana:
+    image: grafana/grafana-oss
+    restart: unless-stopped
+    ports:
+      - '3000:3000'
+    volumes:
+      - grafana-storage:/var/lib/grafana
+      - ./config/grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+
+volumes:
+  grafana-storage: {}

--- a/reload
+++ b/reload
@@ -19,4 +19,4 @@ curl -X POST http://127.0.0.1:9093/-/reload
 curl -X POST http://127.0.0.1:9090/-/reload
 
 # No Reload for grafana so just restart this
-docker compose restart grafana
+docker-compose -p monitor restart grafana

--- a/reload
+++ b/reload
@@ -17,3 +17,6 @@ fi
 curl -X POST http://127.0.0.1:9093/-/reload
 
 curl -X POST http://127.0.0.1:9090/-/reload
+
+# No Reload for grafana so just restart this
+docker compose restart grafana


### PR DESCRIPTION
This PR will
* Run up Grafana instance pointed to prometheus as data source
* Add alert when disk space is over 80%
* Add an alert when disk space will fill up in next 2 weeks (might be obsolete with the above alert)

I've also updated the knowledge base article on monitoring https://mrc-ide.myjetbrains.com/youtrack/articles/RESIDE-A-22/Monitoring

There are instructions there for how to view the system monitor, at the moment this is available for hint instances, buildkite agents, montagu prod and annex

Here is a screenshot where we can see the spike in usage from the other morning when people were using the app in Uganda

![image](https://github.com/vimc/montagu-monitor/assets/39248272/533936c3-4f87-48a5-9772-38f5451b514b)

I will add a proxy around this as a next step. I think this will address ticket [mrc-3920](https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-3920) too
