### PR TITLE
Fix issue with prometheus connecting to alertmanager

### DIFF
--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -1,6 +1,7 @@
 alerting:
   alertmanagers:
-    - static_configs:
+    - path_prefix: "alertmanager/"
+      static_configs:
         - targets: ['alertmanager:9093']
 
 scrape_configs:

--- a/reload
+++ b/reload
@@ -14,9 +14,9 @@ fi
 # Put secrets into configs
 ./config/configure.py $1
 
-curl -X POST http://127.0.0.1:9093/-/reload
+curl -X POST -L http://localhost/alertmanager/-/reload
 
-curl -X POST http://127.0.0.1:9090/-/reload
+curl -X POST -L http://localhost/prometheus/-/reload
 
 # No Reload for grafana so just restart this
 docker-compose -p monitor restart grafana


### PR DESCRIPTION
Naomi production was down for a couple of hours but we didn't get any alerts.. so something was up. Turns out prometheus has just not been communicating with alertmanager. Think this must have been since I did the last bit of work on this ~ 5 months ago :scream: 

Can confirm we are getting alerts after this https://resideglobal.slack.com/archives/C05HQMH482H/p1719482721208409

I also fixed up the reload script which had also rotted