### PR TITLE
Scrape packit.dide.ic.ac.uk 

### DIFF
--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -151,7 +151,7 @@ scrape_configs:
 
   - job_name: 'packit.dide.ic.ac.uk'
     http_sd_configs:
-      - url: "http://packit.dide.ic.ac.uk:9000"
+      - url: "http://packit.dide.ic.ac.uk:9000/targets"
     relabel_configs:
       - target_label: instance
         replacement: packit.dide.ic.ac.uk

--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -149,6 +149,12 @@ scrape_configs:
         regex: (wpia-annex2)(.+)
         replacement: 'montagu annex'
 
+  - job_name: 'packit.dide.ic.ac.uk'
+    http_sd_configs:
+      - url: "http://packit.dide.ic.ac.uk:9000"
+    relabel_configs:
+      - target_label: instance
+        replacement: packit.dide.ic.ac.uk
 
 rule_files:
   - alert-rules.yml


### PR DESCRIPTION
Rather than hardcoding a list of targets to scrape, the configuration uses an HTTP-based service discovery. The packit.dide.ic.ac.uk machine is configured to expose a JSON document on port 9000. This will allow Prometheus to automatically discover new endpoints as we add new instances.

Currently, the services being exposed are one node_exporter for the whole machine, and one outpack_server for each instance hosted on the server. Packit does not yet have a metrics endpoint.