### PR TITLE
Deploy the rrq.dashboard service.

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -105,6 +105,10 @@ http {
             proxy_set_header Host $http_host;
             proxy_pass http://grafana:3000;
         }
+
+        location /rrq/ {
+            proxy_pass http://rrq-dashboard:8888;
+        }
     }
 
     # Redirect all http requests to the SSL endpoint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,14 @@ services:
       - ./config/grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml:ro
       - ./config/grafana/grafana.ini:/etc/grafana/grafana.ini:ro
 
+  rrq-dashboard:
+    image: mrcide/rrq.dashboard:main
+    restart: unless-stopped
+    ports:
+      - '8888:8888'
+    environment:
+      REDIS_URL: wpia-hn.hpc.dide.ic.ac.uk
+
   proxy:
     image: nginx
     restart: unless-stopped


### PR DESCRIPTION
This is exposed by the nginx proxy under https://bots.dide.ic.ac.uk/rrq.