### PR TITLE
Fix the relabel config for Packit.

### DIFF
--- a/config/prometheus.template.yml
+++ b/config/prometheus.template.yml
@@ -134,7 +134,7 @@ scrape_configs:
     relabel_configs:
       # The default instance label has the form hostname:port.
       # The port isn't particularly relevant, so we remove it.
-      - source_labels: [instance]
+      - source_labels: [__address__]
         regex: (.+):(.+)
         target_label: instance
         replacement: $1


### PR DESCRIPTION
The relabel rule was trying to rewrite the instance label, but was not working. It seems as though at the point where it runs there is no instance label yet. It only gets set later in the process to `__address__` if not set anywhere else.

Using `__address__` directly fixes that and makes the relabel rule work as intended.