### PR TITLE
Skip TLS cert verification when reloading.

### DIFF
--- a/reload
+++ b/reload
@@ -14,9 +14,9 @@ fi
 # Put secrets into configs
 ./config/configure.py $1
 
-curl -X POST -L http://localhost/alertmanager/-/reload
+curl -X POST --insecure -L http://localhost/alertmanager/-/reload
 
-curl -X POST -L http://localhost/prometheus/-/reload
+curl -X POST --insecure -L http://localhost/prometheus/-/reload
 
 # No Reload for grafana so just restart this
 docker-compose -p monitor restart grafana


### PR DESCRIPTION
As part of vimc/montagu-monitor#40 I changed the nginx configuration such that it redirects to TLS for all hostnames, not just the `bots.dide.ic.ac.uk`. This was done to simplify the nginx configuration and not need any templating of the file based on the domain name.

It wouldn't have made any difference since the server is only ever accessed through that domain name, if not for the reload script, which uses `localhost` to access the server.

Because of this, the reload script now gets redirected to TLS and fails validation because the hostname in the certificate is not "localhost".

There's a bunch of ways this could be fixed, but the simplest is to just skip TLS validation in the reload script. This is a local communication anyway and we aren't sending any actual information in the requests. It isn't any worst than the previous situation where it was happening over plain HTTP.