### PR TITLE
Simplify the prometheus template.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 aws_configuration
 .idea/*
 config/alertmanager/alertmanager.yml
-config/prometheus/prometheus.yml
+config/prometheus/machine-metrics.json
+config/prometheus/env
 config/prom2teams/config.ini
 config/__pycache__/*
 config/buildkite.env

--- a/config/configure.py
+++ b/config/configure.py
@@ -8,6 +8,7 @@ from os.path import dirname, realpath
 from pathlib import Path
 from docopt import docopt
 from mako.template import Template
+import json
 
 from vault.vault import VaultClient
 
@@ -25,27 +26,30 @@ def instantiate_config(template_path, target_path, values):
 # somewhere as we can't use data from after the scraping in the
 # rename config. And having this here is a bit more explicit than
 # having the renaming done in grafana
-node_exporter_metrics_targets = {
-    "montagu.vaccineimpact.org:9100": "montagu prod",
-    "wpia-annex2.montagu.dide.ic.ac.uk:9100": "annex",
-    "14.0.0.2:9100": "reside-bk1",
-    "14.0.0.3:9100": "reside-bk2",
-    "14.0.0.4:9100": "reside-bk3",
-    "14.0.0.5:9100": "reside-bk4",
-    "14.0.0.6:9100": "reside-bk5",
-    "14.0.0.7:9100": "reside-bk6",
-    "14.0.0.8:9100": "reside-bk7",
-    "14.0.0.9:9100": "reside-bk8",
-    "14.0.0.10:9100": "reside-deploy1",
-    "14.0.0.11:9100": "reside-bk-browser-test1",
-    "14.0.0.12:9100": "reside-bk-multicore1",
-    "14.0.0.13:9100": "reside-bk-multicore2",
-    "14.0.0.14:9100": "reside-bk-multicore3"
+buildkite_hosts = {
+    "reside-bk1": "14.0.0.2:9100",
+    "reside-bk2": "14.0.0.3:9100",
+    "reside-bk3": "14.0.0.4:9100",
+    "reside-bk4": "14.0.0.5:9100",
+    "reside-bk5": "14.0.0.6:9100",
+    "reside-bk6": "14.0.0.7:9100",
+    "reside-bk7": "14.0.0.8:9100",
+    "reside-bk8": "14.0.0.9:9100",
+    "reside-deploy1": "14.0.0.10:9100",
+    "reside-bk-browser-test1": "14.0.0.11:9100",
+    "reside-bk-multicore1": "14.0.0.12:9100",
+    "reside-bk-multicore2": "14.0.0.13:9100",
+    "reside-bk-multicore3": "14.0.0.14:9100",
 }
 
 
-def relabel_config(ip, target):
-    return ['- targets: ["{}"]'.format(ip), '  labels: ', '    instance: "{}"'.format(target)]
+def buildkite_node_exporter_config(name, ip):
+    return {
+        "targets": [ ip ],
+        "labels": {
+            "instance": name
+        }
+    }
 
 
 if __name__ == "__main__":
@@ -63,9 +67,10 @@ if __name__ == "__main__":
 
     slack_oauth_token = "secret/vimc/slack/oauth-token"
 
-    metrics_targets = []
-    for ip, target in node_exporter_metrics_targets.items():
-        metrics_targets += relabel_config(ip, target)
+    buildkite_targets = [
+        buildkite_node_exporter_config(name, ip)
+        for name, ip in buildkite_hosts.items()
+    ]
 
     Path('alertmanager').mkdir(exist_ok=True)
     instantiate_config(
@@ -74,13 +79,6 @@ if __name__ == "__main__":
         {"slack_oauth_token": vault.read_secret(slack_oauth_token),
          "slack_default_channel": slack_default_channel,
          "slack_hint_channel": slack_hint_channel}
-    )
-    instantiate_config(
-        "prometheus.template.yml",
-        "prometheus/prometheus.yml",
-        {"aws_access_key_id": vault.read_secret("secret/vimc/prometheus/aws_access_key_id"),
-         "aws_secret_key": vault.read_secret("secret/vimc/prometheus/aws_secret_key"),
-         "metrics_targets": "\n      ".join(metrics_targets)}
     )
     instantiate_config(
         "grafana/grafana.template.ini",
@@ -95,5 +93,12 @@ if __name__ == "__main__":
     with open("nginx/key.pem", "w") as f:
         f.write(vault.read_secret("secret/bots/ssl", field="key"))
     with open("buildkite.env", 'w') as f:
-        f.write("BUILDKITE_AGENT_TOKEN={}".format( \
+        f.write("BUILDKITE_AGENT_TOKEN={}".format(
             vault.read_secret("secret/buildkite/agent", "token")))
+    with open("prometheus/env", 'w') as f:
+        f.write("AWS_ACCESS_KEY_ID={}\n".format(
+            vault.read_secret("secret/vimc/prometheus/aws_access_key_id")))
+        f.write("AWS_SECRET_ACCESS_KEY={}\n".format(
+            vault.read_secret("secret/vimc/prometheus/aws_secret_key")))
+    with open("prometheus/machine-metrics.json", "w") as f:
+        json.dump(buildkite_targets, f)

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -78,14 +78,13 @@ scrape_configs:
     scrape_timeout: 60s
     scrape_interval: 2m
     ec2_sd_configs: &ec2
+      # Credentials are passed as environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
       - region: 'eu-west-2'
-        access_key: ${aws_access_key_id}
-        secret_key: ${aws_secret_key}
     relabel_configs:
       - source_labels: [__meta_ec2_public_dns_name]
         target_label: __address__
         regex: (.+)
-        replacement: <%text>$</%text>{1}:5000
+        replacement: $1:5000
 
   - job_name: 'ec2-machine-metrics'
     ec2_sd_configs: *ec2
@@ -93,7 +92,7 @@ scrape_configs:
       - source_labels: [__meta_ec2_public_dns_name]
         target_label: __address__
         regex: (.+)
-        replacement: <%text>$</%text>{1}:9100
+        replacement: $1:9100
 
   - job_name: 'buildkite-metrics'
     static_configs:
@@ -101,31 +100,25 @@ scrape_configs:
 
   - job_name: 'machine-metrics'
     static_configs:
-      - targets: ['naomi.dide.ic.ac.uk:9100']
-        labels:
-          project: hint
-          frequency: high
-      - targets: ['wpia-naomi-preview.dide.ic.ac.uk:9100']
-        labels:
-          project: hint
-      ${metrics_targets}
-    relabel_configs:
-      - source_labels: [__address__]
-        target_label: instance
-        regex: (naomi)(.+)
-        replacement: 'hint production'
-      - source_labels: [__address__]
-        target_label: instance
-        regex: (wpia-naomi-preview)(.+)
-        replacement: 'hint preview'
-      - source_labels: [__address__]
-        target_label: instance
-        regex: (montagu.vaccineimpact)(.+)
-        replacement: 'montagu production'
-      - source_labels: [ __address__ ]
-        target_label: instance
-        regex: (wpia-annex2)(.+)
-        replacement: 'montagu annex'
+    - targets: ['naomi.dide.ic.ac.uk:9100']
+      labels:
+        project: hint
+        frequency: high
+        instance: 'hint production'
+    - targets: ['wpia-naomi-preview.dide.ic.ac.uk:9100']
+      labels:
+        project: hint
+        instance: 'hint preview'
+    - targets: ['montagu.vaccineimpact.org:9100']
+      labels:
+        instance: 'montagu production'
+    - targets: ['wpia-annex2.montagu.dide.ic.ac.uk:9100']
+      labels:
+        instance: 'montagu annex'
+
+    file_sd_configs:
+      - files:
+        - /etc/prometheus/machine-metrics.json
 
   - job_name: 'packit'
     http_sd_configs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-version: '3'
-
+name: monitor
 services:
   prometheus:
     image: prom/prometheus
@@ -11,6 +10,7 @@ services:
       - prometheus-storage:/prometheus
     depends_on:
       - alertmanager
+    env_file: config/prometheus/env
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'

--- a/reload
+++ b/reload
@@ -19,4 +19,4 @@ curl -X POST --insecure -L http://localhost/alertmanager/-/reload
 curl -X POST --insecure -L http://localhost/prometheus/-/reload
 
 # No Reload for grafana so just restart this
-docker-compose -p monitor restart grafana
+docker compose -p monitor restart grafana

--- a/run
+++ b/run
@@ -17,7 +17,7 @@ fi
 # Configure AWS metrics
 ./aws_metrics/config/configure.py
 
-docker-compose -p monitor up --detach --build
+docker compose -p monitor up --detach --build
 
 echo "Now running Montagu Monitor"
 echo "Browse to http://localhost:9090 to see basic output."

--- a/stop
+++ b/stop
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -ex
 
-docker-compose -p monitor down
+docker compose -p monitor down


### PR DESCRIPTION
Using mako as a templating tool adds an extra layer of complexity that isn't necessary. The only two uses were to load a list of targets and to provide AWS credentials, both of which can be achieved through other means.

This also updates to docker compose v2 syntax.