### PR TITLE
Add blackbox probes for most of our services.

### DIFF
--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -173,3 +173,22 @@ groups:
         for: 5m
         annotations:
           error: "redis is down: {{ $labels.instance }}"
+
+  - name: blackbox
+    rules:
+      - alert: BlackBoxHttpDown
+        expr: up{job="blackbox-http"} == 0
+        for: 5m
+        annotations:
+          error: "blackbox-http scrape is down: '{{ $labels.instance }}'"
+
+      - alert: BlackBoxProbeFailed
+        expr: probe_success == 0
+        for: 5m
+        annotations:
+          error: "probe failed: '{{ $labels.instance }}'"
+
+      - alert: CertificateExpiry30Days
+        expr: probe_ssl_earliest_cert_expiry - time() < 30d
+        annotations:
+          error: "certificate expires in {{ humanizeDuration .Value }}: '{{ $labels.instance }}'"

--- a/config/prometheus/blackbox-probes.yaml
+++ b/config/prometheus/blackbox-probes.yaml
@@ -1,0 +1,58 @@
+- targets:
+  - https://bots.dide.ic.ac.uk
+  - https://data.dide.ic.ac.uk
+  - https://mrcdata.dide.ic.ac.uk
+  - https://vault.dide.ic.ac.uk:8200
+  - https://www.infectiousdiseasemodels.org
+
+- targets:
+  - https://beebop.dide.ic.ac.uk
+  - https://beebop-dev.dide.ic.ac.uk
+  labels:
+    project: beebop
+
+- targets:
+  - https://daedalus.jameel-institute.org
+  - https://daedalus-dev.dide.ic.ac.uk
+  labels:
+    project: daedalus
+
+- targets:
+  - https://www.vaccineimpact.org
+  - https://montagu.vaccineimpact.org
+  - https://science.montagu.dide.ic.ac.uk
+  - https://uat.montagu.dide.ic.ac.uk
+  labels:
+    project: montagu
+
+- targets:
+  - https://mint.dide.ic.ac.uk
+  - https://mint-dev.dide.ic.ac.uk
+  labels:
+    project: mint
+
+# These are set to become Avenir's responsibility in the near future.
+- targets:
+  - https://naomi.unaids.org
+  - https://naomi-preview.dide.ic.ac.uk
+  labels:
+    project: naomi
+
+- targets:
+  - https://packit.dide.ic.ac.uk
+  - https://packit-dev.dide.ic.ac.uk
+  - https://packit-private.dide.ic.ac.uk
+  labels:
+    project: packit
+
+- targets:
+  - https://shiny.dide.ic.ac.uk
+  - https://shiny-dev.dide.ic.ac.uk
+  labels:
+    project: shiny
+
+- targets:
+  - https://epimodels.dide.ic.ac.uk
+  - https://wodin-dev.dide.ic.ac.uk
+  labels:
+    project: wodin

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -158,5 +158,24 @@ scrape_configs:
       - target_label: __address__
         replacement: redis-exporter:9121
 
+  - job_name: 'blackbox-http'
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    file_sd_configs:
+      - files: [ /etc/prometheus/blackbox-probes.yaml ]
+
+    # See https://github.com/prometheus/blackbox_exporter/blob/master/README.md#prometheus-configuration
+    # This rewrites the metrics URL as blackbox:9115?target=https://foo.dide.ic.ac.uk
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+        regex: ^(.*://)?(.*?)(:\d+)?$
+        replacement: $2
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+
 rule_files:
   - alert-rules.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,10 @@ services:
     environment:
       REDIS_URL: wpia-hn.hpc.dide.ic.ac.uk
 
+  blackbox-exporter:
+    image: quay.io/prometheus/blackbox-exporter:latest
+    restart: unless-stopped
+
   proxy:
     image: nginx
     restart: unless-stopped


### PR DESCRIPTION
This adds an HTTPS probe for all the services we run. It can allow us to at a glance check the liveness of our services. It also reports certificate expiry time.

The list of services is the union from a list provided by Wes and a search for valid as of today certificates for 'dide.ic.ac.uk' subdomains on crt.sh.

```sh
curl -s 'https://crt.sh/json?dnsname=dide.ic.ac.uk&exclude=expired' | jq -r 'map(.common_name) | unique | .[]'
```

Some hostnames were excluded:
- `naomi-dev.dide` and `naomi-staging.dide` don't exist anymore won't be coming back.
- `hipercow.dide` does not exist yet
- `ebola2018.dide`, `mpox.dide` and `ncov.dide` are presumed to have been decomissioned.
- `orderly.dide`, `hiv-orderly.dide`, `malaria-orderly.dide` don't seem to exist, and are superseeded by Packit.
- `logs.dide` is dead. Maybe one day we will bring it back, but not in the short term.
- `daedalus.dide` and `production2.montagu.dide` are internal DNS names that have equivalent external names. The external names are monitored.

Three hosts are currently failing:
- `daedalus-dev.dide` is temporarily down.
- `mint-dev.dide` and `shiny-dev.dide` have expired certificates. The CT logs says valid certs for these exist, they probably just haven't been deployed.

I will keep the failing hosts in the config, and manually silence them
for now after deploying this.