### PR TITLE
Add scraping of wpia-hn's redis instance.

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -132,5 +132,22 @@ scrape_configs:
         target_label: instance
         replacement: $1
 
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['redis://wpia-hn.hpc.dide.ic.ac.uk']
+    metrics_path: /scrape
+
+    # See https://github.com/oliver006/redis_exporter/blob/master/README.md#prometheus-configuration-to-scrape-multiple-redis-hosts
+    # This rewrites the metrics URL as redis-exporter:9115/scrape?target=<...>
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+        regex: .+://(.+)
+        replacement: $1
+      - target_label: __address__
+        replacement: redis-exporter:9121
+
 rule_files:
   - alert-rules.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,10 @@ services:
       - '80:80'
       - '443:443'
 
+  redis-exporter:
+    image: oliver006/redis_exporter
+    restart: unless-stopped
+
 volumes:
   grafana-storage: {}
   prometheus-storage: {}


### PR DESCRIPTION
This will help keep an eye of the size and growth of the database, as well as queries latency. I was initially hoping to monitor error rates as well, but it seems our Redis instance is fairly old and doesn't expose these statistics.

This uses redis-exporter as a bridge between redis and prometheus. In theory a single instance of the exporter can be used to monitor any number of redis server's, although at the moment only the wpia-hn is configured. We may want to add hint and/or daedalus' servers in the future.

It seems redis has native support for prometheus in [its enterprise offering][redis-metrics], but not something we get to use.

[redis-metrics]: https://redis.io/docs/latest/integrate/prometheus-with-redis-enterprise/prometheus-metrics-definitions/