### PR TITLE
Set the correct scrape interval in Grafana.

### DIFF
--- a/config/grafana/datasource.yml
+++ b/config/grafana/datasource.yml
@@ -52,6 +52,9 @@ datasources:
       # <bool> Enables TLS authentication using a CA
       # certificate.
       tlsAuthWithCACert: false
+
+      # This needs to match the prometheus configuration
+      timeInterval: 1m
     # <map> Fields to encrypt before storing in jsonData.
     secureJsonData:
       # <string> Defines the CA cert, client cert, and

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -1,3 +1,7 @@
+global:
+  # This is the Prometheus default already, but lets be explicit about it.
+  scrape_interval: 1m
+
 alerting:
   alertmanagers:
     - path_prefix: "alertmanager/"


### PR DESCRIPTION
When using the `rate()` operator, one needs to provide a suitable interval. Grafana provides a `$__rate_interval` variable that can be used as the interval, however this variable only works correctly if Grafana knows about Prometheus' scrape interval.

Unfortunately, Prometheus' default scrape interval is one minute, whereas Grafana assumes it to be 15 seconds. This breaks the automatic rate interval when zooming in too much.

https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/