### PR TITLE
Clean up the datasource.yml file.

### DIFF
--- a/config/grafana/datasource.yml
+++ b/config/grafana/datasource.yml
@@ -1,74 +1,25 @@
-# Configuration file version
 apiVersion: 1
 
-# List of data sources to delete from the database.
-deleteDatasources:
-  - name: Prometheus
-    orgId: 1
-
-# List of data sources to insert/update depending on what's
-# available in the database.
 datasources:
-  # <string, required> Sets the name you use to refer to
-  # the data source in panels and queries.
   - name: Prometheus
-    # <string, required> Sets the data source type.
-    type: prometheus
-    # <string, required> Sets the access mode, either
-    # proxy or direct (Server or Browser in the UI).
-    # Some data sources are incompatible with any setting
-    # but proxy (Server).
-    access: proxy
-    # <int> Sets the organization id. Defaults to orgId 1.
     orgId: 1
-    # <string> Sets a custom UID to reference this
-    # data source in other parts of the configuration.
-    # If not specified, Grafana generates one.
-    uid: my_unique_uid
-    # <string> Sets the data source's URL, including the
-    # port.
-    url: http://prometheus:9090/prometheus
-    # <string> Sets the database user, if necessary.
-    user:
-    # <string> Sets the database name, if necessary.
-    database:
-    # <bool> Enables basic authorization.
-    basicAuth:
-    # <string> Sets the basic authorization username.
-    basicAuthUser:
-    # <bool> Enables credential headers.
-    withCredentials:
-    # <bool> Toggles whether the data source is pre-selected
-    # for new panels. You can set only one default
-    # data source per organization.
-    isDefault:
-    # <map> Fields to convert to JSON and store in jsonData.
-    jsonData:
-      # <string> Defines the Graphite service's version.
-      graphiteVersion: '1.1'
-      # <bool> Enables TLS authentication using a client
-      # certificate configured in secureJsonData.
-      tlsAuth: false
-      # <bool> Enables TLS authentication using a CA
-      # certificate.
-      tlsAuthWithCACert: false
 
-      # This needs to match the prometheus configuration
-      timeInterval: 1m
-    # <map> Fields to encrypt before storing in jsonData.
-    secureJsonData:
-      # <string> Defines the CA cert, client cert, and
-      # client key for encrypted authentication.
-      tlsCACert: '...'
-      tlsClientCert: '...'
-      tlsClientKey: '...'
-      # <string> Sets the database password, if necessary.
-      password:
-      # <string> Sets the basic authorization password.
-      basicAuthPassword:
-    # <int> Sets the version. Used to compare versions when
-    # updating. Ignored when creating a new data source.
-    version: 1
-    # <bool> Allows users to edit data sources from the
-    # Grafana UI.
+    # This ID is referenced by dashboards, which unfortunately makes it
+    # difficult for us to change it to something actually unique.
+    uid: my_unique_uid
+
+    type: prometheus
+    url: http://prometheus:9090/prometheus
+
+    # Proxy requests to Prometheus through the Grafana server, instead of
+    # making browsers talk directly to the Prometheus server.
+    access: proxy
+
+    # Prevent edits from the Web UI: we want all configuration to come from
+    # this file.
     editable: false
+
+    jsonData:
+      # This needs to match the prometheus configuration
+      # It is used to derive the $__rate_interval variable.
+      timeInterval: 1m


### PR DESCRIPTION
The file had been copied from the website and contained a lot of unnecessary entries. Some of it already matched the default values and some of it was entirely unused (eg. options that apply to non-prometheus data sources only).

I've cleaned it up to contain only the essential bits. I've also removed the `deleteDatasources` section: rather than deleting and creating new data sources, Grafana can update the existing one. The behaviour is roughly equivalent.