### PR TITLE
Allow anonymous access to Grafana.

### DIFF
--- a/config/grafana/grafana.template.ini
+++ b/config/grafana/grafana.template.ini
@@ -6,3 +6,8 @@ serve_from_sub_path = true
 [security]
 admin_user = admin
 admin_password = ${admin_password}
+
+[auth.anonymous]
+enabled = true
+org_name = Main Org.
+org_role = Viewer


### PR DESCRIPTION
We have a shared password (stored in Vault) that is used to restrict access to Grafana. Given that Prometheus, the underlying datasource, already allows unauthenticated access to the metrics, putting access restrictions on Grafana doesn't protect anything and makes sharing dashboards with other people tedious.

Modifying dashboards will still require logging in. A "Sign in" button is present in the top-right of the webpage.

https://grafana.com/docs/grafana/v11.4/setup-grafana/configure-security/configure-authentication/#anonymous-authentication