### PR TITLE
Add a volume for alertmanager's data.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     restart: always
     volumes:
       - "./config/alertmanager:/etc/alertmanager:ro"
+      - alertmanager-storage:/alertmanager
     ports:
       - "9093:9093"
     command:
@@ -83,3 +84,4 @@ services:
 volumes:
   grafana-storage: {}
   prometheus-storage: {}
+  alertmanager-storage: {}


### PR DESCRIPTION
Alertmanager stores its silences on disk at the `/alertmanager` path. Unless we mount a volume at that location, all silences are lost whenever the container is restarted, leading to lots of noise and redundant alerts.

Mounting a volume at that location fixes the issue.