### PR TITLE
Reduce the frequency of PackitConfigDrift alerts.

### DIFF
--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -10,17 +10,25 @@ route:
         - frequency = high
       repeat_interval: 20m
       receiver: 'slack-hint'
+
     - matchers:
         - project = hint
       repeat_interval: 4h
       receiver: 'slack-hint'
+
     - matchers:
         - frequency = high
       repeat_interval: 20m
       receiver: 'slack-default'
+
     - matchers:
         - frequency = low
       repeat_interval: 24h
+      receiver: 'slack-default'
+
+    - matchers:
+        - frequency = weekly
+      repeat_interval: 1w
       receiver: 'slack-default'
 
 templates:

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -153,3 +153,5 @@ groups:
         for: 1w
         annotations:
           error: "NixOS configuration is out-of-sync: '{{ $labels.instance }}'"
+        labels:
+          frequency: "weekly"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
       - '--web.external-url=https://bots.dide.ic.ac.uk/alertmanager'
+      # Two weeks of data rentention: this is necessary to support long repeat
+      # intervals for alerts.
+      - '--data.retention=336h'
 
   buildkite_metrics:
     image: reside/buildkite-agent-metrics


### PR DESCRIPTION
These are not time sensitive or of a high severity. We only have those alerts to avoid forgetting to deploy. Once a week notice is enough (it already takes a week to fire the first time).

For this to work we need to increase alertmanager's data retention period, now at two weeks. The default value was 120h.