### PR TITLE
Reduce the TLS expiry from 30 days to three weeks.

### DIFF
--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -133,8 +133,10 @@ groups:
         annotations:
           error: "probe failed: '{{ $labels.instance }}'"
 
-      - alert: CertificateExpiry30Days
-        expr: probe_ssl_earliest_cert_expiry - time() < 30d
+      # The standard certbot configuration is to renew 30 days before expiry.
+      # We give it an extra week or so before
+      - alert: CertificateExpiry
+        expr: probe_ssl_earliest_cert_expiry - time() < 21d
         annotations:
           error: "certificate expires in {{ humanizeDuration .Value }}: '{{ $labels.instance }}'"
 


### PR DESCRIPTION
By default Certbot renews Let's Encrypt certificates 30 days before they are due to expire. We had an alert set to the same period, which would fire and notify us even though certbot was about to perform the renewal.

Using a shorter duration will avoid this issue. 21 days (or three weeks) seems like a reasonable value, giving us enough time to intervene manually if necessary.

We could make the rule conditional on the issuer, eg. use a shorter duration for automatically issued certificates and a longer one for manually issued ones, but that doesn't seem worth the extra complexity.