### PR TITLE
Increase the scrape rate of the GitHub exporter.

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -156,9 +156,12 @@ scrape_configs:
         replacement: blackbox-exporter:9115
 
   - job_name: 'github'
-    # We don't particular care about being very up-to-date, so do our best to
-    # avoid wasting GitHub rate limit credit.
-    scrape_interval: 10m
+
+    # We don't particular care about being very up-to-date, so we reduce the
+    # scraping rate to avoid wasting GitHub rate limit credit. We don't want to
+    # go over 5 minutes though or Prometheus consideres the data to be stale:
+    # https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness
+    scrape_interval: 3m
     metrics_path: /scrape
     static_configs:
       - targets: ['reside-ic/packit-infra']


### PR DESCRIPTION
To avoid wasting GitHub rate limit credit, we were using a long scrape interval (10 minutes) on the GitHub exporter. Unfortunately, after 5 minutes Prometheus considers the samples to be stale, which could lead to some alerts and confusing graphs.

GitHub's rate limit for unauthenticated request is 60 per hour. Using 3 minutes as the scraping interval leads to 20 requests per minute, assuming we only need one request per scrape, which is currently the case.

If rate limit ever becomes a big concern, we can start using an access token which will raise the limit to 5000 requests per hour.

Alternatively, we can introduce caching inside the exporter and use conditional requests to the GitHub API. According to GitHub, if their API returns a 304 response the request is not counted towards our rate limit. However from a quick experiment, this is true only if the request is authenticated in the first place.