### PR TITLE
Increase Prometheus retention from 2 weeks to 2 months (60 days).

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -9,6 +9,21 @@ alerting:
         - targets: ['alertmanager:9093']
 
 scrape_configs:
+  - job_name: 'prometheus'
+    # This needs to match the web.external-url flag we use to run prometheus.
+    metrics_path: /prometheus/metrics
+    static_configs:
+      - targets: ['127.0.0.1:9090']
+
+  - job_name: 'alertmanager'
+    metrics_path: /alertmanager/metrics
+    static_configs:
+      - targets: ['alertmanager:9093']
+
+  - job_name: 'grafana'
+    metrics_path: /grafana/metrics
+    static_configs:
+      - targets: ['grafana:3000']
 
   - job_name: 'proxy-metrics'
     static_configs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=60d'
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
       # --web.enable-lifecycle enables reloading new config, see: https://prometheus.io/docs/operating/security/


### PR DESCRIPTION
We currently use about 600MB of disk space on metrics retention. Multiplying this by 4 seems reasonable. The bots VM has 30GB of free disk space at the moment.

Added rules for Prometheus to scrape itself as well as Alertmanager and Grafana. Obviously this doesn't help catch Prometheus going down, but it does allow us to monitor its state, including disk usage.