### PR TITLE
Add exporters for wpia-gpu-01 and wpia-gpu-02.

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -102,10 +102,20 @@ scrape_configs:
     - targets: ['wpia-annex2.montagu.dide.ic.ac.uk:9100']
       labels:
         instance: 'montagu annex'
+    - targets:
+      - wpia-gpu-01.dide.ic.ac.uk:9100
+      - wpia-gpu-02.dide.ic.ac.uk:9100
 
     file_sd_configs:
       - files:
         - /etc/prometheus/machine-metrics.json
+
+  - job_name: 'DCGM'
+    static_configs:
+    - targets:
+      # DCGM-exporter is only running on GPU-01 for now because GPU-02 is
+      # running an older Ubuntu version where it isn't packaged.
+      - wpia-gpu-01.dide.ic.ac.uk:9400
 
   # The packit servers have a whole slew of services we want to scrape. To ease
   # configuration, each server exposes a JSON document that lists them all.


### PR DESCRIPTION
This will let us monitor occupancy and disk usage.

I installed the node_exporter by simply using `apt install prometheus-node-exporter` instead of the ["machine-metrics"][machine-metrics] scripts we have used in the past.

NVidia also offers [an exporter to gather GPU-specific metrics][dcgm-exporter]. For now this is only running on gpu-01, as the package I installed isn't available on the old Ubuntu distribution that is running on gpu-02.

```
sudo apt install datacenter-gpu-manager-4-cuda12 datacenter-gpu-manager-exporter
sudo systemctl enable --now nvidia-dcgm-exporter.service
```

[machine-metrics]: https://github.com/vimc/machine-metrics
[dcgm-exporter]: https://docs.nvidia.com/datacenter/dcgm/latest/gpu-telemetry/dcgm-exporter.html