### PR TITLE
Fix and improve DiskWillFillIn2Weeks metric.

### DIFF
--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -100,7 +100,7 @@ groups:
         annotations:
           error: "Mountpoint {{ $labels.mountpoint }} on {{ $labels.instance }} is over 80% full"
       - alert: DiskWillFillIn2Weeks
-        expr: predict_linear(node_filesystem_free{job="machine-metrics"}[1h], 2w) < 0
+        expr: predict_linear(node_filesystem_free_bytes{job="machine-metrics"}[24h], 2w) < 0
         for: 5m
         annotations:
           error: "Mountpoint {{ $labels.mountpoint }} on {{ $labels.instance }} will be full in 2 weeks"


### PR DESCRIPTION
This adds the missing `_bytes` suffix to the `node_filesystem_free` metric used by the alert. The name was changed way back in node_exporter 0.16.0, released in 2018. I suspect this alert has never actually worked.

I've also changed the range used to calculate the linear interpolation from 1 hour to 1 day. It is reasonably easy for a sudden download to trigger the alert when extrapolating one hour to two weeks: a 3GB increase over an hour is roughly 1TB over two weeks. Using a whole day should help avoid false positives.