### PR TITLE
Exclude cifs mountpoints from the disk space alerts.

### DIFF
--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -95,7 +95,7 @@ groups:
   - name: disk-usage
     rules:
       - alert: DiskNearlyFull
-        expr: (100 - (avg_over_time(node_filesystem_avail_bytes{job="machine-metrics"}[1h]) * 100) / avg_over_time(node_filesystem_size_bytes{job="machine-metrics"}[1h])) > 80
+        expr: (100 - (avg_over_time(node_filesystem_avail_bytes{job="machine-metrics", fstype!="cifs"}[1h]) * 100) / avg_over_time(node_filesystem_size_bytes[1h])) > 80
         for: 5m
         annotations:
           error: "Mountpoint {{ $labels.mountpoint }} on {{ $labels.instance }} is over 80% full"


### PR DESCRIPTION
CIFS mounts represent network drives. These are managed externally and do not represent the health of the individual machines.

While it might be useful to have an eye on these drives, if we do it we should do it in a consistent way, not just on the drives that we happen to have mounted.

For reference the Climate drive (mounted on GPU-02) is currently at 83% occupation, and the Q drive (mounted on GPU-01) is just under 80%.