### PR TITLE
Scrape node_exporter from bots.

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -103,6 +103,7 @@ scrape_configs:
       labels:
         instance: 'montagu annex'
     - targets:
+      - bots.dide.ic.ac.uk:9100
       - wpia-gpu-01.dide.ic.ac.uk:9100
       - wpia-gpu-02.dide.ic.ac.uk:9100
     relabel_configs:


### PR DESCRIPTION
We managed to run out of disk space on that VM without any warning. Running node_exporter and monitoring it gives us our usual 80% disk usage alerts.