### PR TITLE
Remove last remnants of AWS configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .idea/*
 config/alertmanager/alertmanager.yml
 config/prometheus/generated
-config/prometheus/env
 config/__pycache__/*
 config/buildkite.env
 config/grafana/grafana.ini

--- a/config/configure.py
+++ b/config/configure.py
@@ -88,8 +88,3 @@ if __name__ == "__main__":
     with open("buildkite.env", 'w') as f:
         f.write("BUILDKITE_AGENT_TOKEN={}".format(
             vault.read_secret("secret/buildkite/agent", "token")))
-    with open("prometheus/env", 'w') as f:
-        f.write("AWS_ACCESS_KEY_ID={}\n".format(
-            vault.read_secret("secret/vimc/prometheus/aws_access_key_id")))
-        f.write("AWS_SECRET_ACCESS_KEY={}\n".format(
-            vault.read_secret("secret/vimc/prometheus/aws_secret_key")))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - prometheus-storage:/prometheus
     depends_on:
       - alertmanager
-    env_file: config/prometheus/env
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'


### PR DESCRIPTION
We used to connect to AWS to fetch metrics from barman and bb8, but this had been broken for a while and was removed from the scrape rules some time ago. We still had some code left in place to fetch AWS credentials from Vault, which is not necessary anymore.