### PR TITLE
Add missing newline between alert bullet points.

### DIFF
--- a/config/alertmanager/templates/slack-alert-text.tmpl
+++ b/config/alertmanager/templates/slack-alert-text.tmpl
@@ -13,7 +13,7 @@
 {{- end }}
 
 {{ define "slack.text" -}}
-  {{- range .Alerts -}}
-    * {{ if eq .Status "firing" }}{{ .Annotations.error }}{{ else }}~{{ .Annotations.error }}~{{ end }}
+  {{- range .Alerts }}
+* {{ if eq .Status "firing" }}{{ .Annotations.error }}{{ else }}~{{ .Annotations.error }}~{{ end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The alert template was using minus signs in its directives to suppress superfluous whitespaces. This had the unintended consequence of putting all the bullets on the same line in cases where alerts have been grouped together.

See the [text/template][godocs] documentation for reference about the template syntax.

[godocs]: https://pkg.go.dev/text/template#hdr-Text_and_spaces

The Slack API that alertmanager uses to post Slack messages doesn't actually support formatted bullet points, but separate lines with leading asterisks is good enough.