### PR TITLE
Add playbooks for DiskNearlyFull and PackitConfigDrift.

### DIFF
--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -37,6 +37,10 @@ receivers:
           - text: 'Silence'
             type: button
             url: '{{ template "__alert_silence_link" . }}'
+          # Not all alerts have an associated playbook. The button is invisible if the URL field is empty.
+          - text: 'Playbook'
+            type: button
+            url: '{{ (index .Alerts 0).Annotations.playbook }}'
           - text: 'Docs'
             type: button
             url: 'https://mrc-ide.myjetbrains.com/youtrack/articles/RESIDE-A-22/Monitoring'

--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -99,6 +99,7 @@ groups:
         for: 5m
         annotations:
           error: "Mountpoint {{ $labels.mountpoint }} on {{ $labels.instance }} is over 80% full"
+          playbook: https://github.com/vimc/montagu-monitor/blob/main/playbooks/DiskNearlyFull.md
 
   - name: redis
     rules:
@@ -149,5 +150,6 @@ groups:
         for: 1w
         annotations:
           error: "NixOS configuration is out-of-sync: '{{ $labels.instance }}'"
+          playbook: https://github.com/vimc/montagu-monitor/blob/main/playbooks/PackitConfigDrift.md
         labels:
           frequency: "weekly"

--- a/playbooks/DiskNearlyFull.md
+++ b/playbooks/DiskNearlyFull.md
@@ -1,0 +1,55 @@
+# DiskNearlyFull
+
+This alert is triggered when a disk is over 80% full. We use this alert
+across all monitored machines. Diagnosis and resolution is likely to differ
+on a case-by-case basis.
+
+The alert will mention the hostname and the mountpoint of the drive in
+question.
+
+## wpia-gpu-02
+
+The GPU nodes, in particular GPU02, often end up accumulating lots of software
+and data from its users which they don't always clean up and which, if left
+unchecked, grows endlessly.
+
+The following command will list all directories in the `/home` directory and
+sort them by descending size:
+
+```sh
+sudo du -x -d 1 -h /home | sort -hr
+```
+
+If a particular user stands out in this list, you can contact them asking them
+to remove any old data or software they may have lying around.
+
+In addition to the root drive (which is "only" 400GB), the machine is equipped
+with a very large drive mounted under `/data`. Users should be encouraged to
+move any voluminous data to that drive.
+
+The first time they need access to the `/data` drive, you can create a new
+folder for them using the following command, replacing all instances of
+`<USER>` with their username on that machine (which may not be the same as
+their DIDE or IC username):
+
+```sh
+sudo install -d -o <USER> -g <USER> /data/<USER>
+```
+
+## `/boot` partition
+
+After a kernel upgrades, the `/boot` partition may grow in size if the old
+kernels aren't pruned. While Ubuntu should be handling automatically,
+occasionally this does not seem to work as expected and old kernels can
+accumulate.
+
+Apt will avoid uninstalling the kernel that is currently booted: rebooting the
+machine into the latest installed kernel followed by an `apt autoremove` can be
+used to prune these kernel versions.
+
+## Network and Pseudo filesystems
+
+The metrics and alert are configured to ignored network and pseudo file system
+types, including cifs (aka Windows network drives), procfs, sysfs, etc. In the
+future it may be necessary to exclude additional file system types if new ones
+crop up. This can be done most easily by modifying the alert definition.

--- a/playbooks/PackitConfigDrift.md
+++ b/playbooks/PackitConfigDrift.md
@@ -1,0 +1,93 @@
+# PackitConfigDrift
+
+This alert is raised when the configuration that is deployed onto one of the
+NixOS-based hosts does not match the state of the main branch of the
+[`reside-ic/packit-infra` repository][packit-infra].
+
+The packit-infra repository holds a declarative configuration of the operating
+system. Under normal operation, all NixOS machines should be deployed from the
+main branch of this repository. However it is possible for the machines to
+become out of sync with the repository. There are two main scenarios when this
+may happen:
+
+- A pull-request is merged into the main branch of the repository and is not
+  deployed to the machine.
+- A branch is deployed to the machine and is not merged to main (or is merged
+  with further modifications).
+
+Both of these conditions are generally harmless, and these are in fact expected
+to happen transiently as part of the normal develop-test-merge-deploy cycle.
+For this reason, the alert only fires after a week of divergence.
+
+They do however become an issue if left unaddressed for an extended period of
+time. Over time context is forgotten and it becomes unclear why a given
+machine's actual state does not match expectations. This leads to uncertainty
+and doubt when new changes need to be deployed.
+
+## Diagnosis
+
+Resolving the alert can be as simple as re-deploying the main branch to the
+affected server. However before doing so it is important to compare the
+expected and actual configurations to make sure we understand the situtation
+and are not, for example, rolling back important changes.
+
+There are two ways we can compare the configuration: we can compare the source
+Nix files or we can compare the result of their evaluation. Comparing the
+source is generally more readable and easier to understand, but it requires
+access to the exact commit that was used to deploy to the server.
+
+### Comparing configuration sources
+
+The first step is to identify the Git revision of the configuration that was
+last deployed to the server.  This is exposed in [Prometheus][prometheus] as
+the `revision` label of the `nixos_configuration_info` metric.
+
+If the `revision` label ends with the `-dirty` suffix then the configuration
+was deployed from a dirty Git working directory and the revision shown is not a
+true representative of the configuration that was deployed. Similarly, even if
+the worktree was clean and the revision does not have a `-dirty` suffix, if the
+commit in question was never pushed to GitHub it may not be available for
+comparison.  In either cases, one must fall back to comparing the evaluated
+derivation, as explained below.
+
+If however the revision is not dirty and is available on GitHub (or in a local
+clone of the repository), one can use the usual Git tools to compare the two
+revisions. For example, use the GitHub interface to compare the commits,
+replacing `<REV>` with the commit hash that was obtained from the metric:
+`https://github.com/reside-ic/packit-infra/compare/main..<REV>`. GitHub
+supports ["two-dot" and "three-dot" comparisons][two-dots] - in this context
+using a two-dot comparison is generally preferable.
+
+### Comparing configuration evaluations
+
+If the original source used to deploy the configuration is not available any
+more, as a last resort one can compare the evaluated derivation instead.
+
+The `packit-infra` repository includes a tool that can do this. The following
+command will connect to the given host, retrieve its evaluated configuration,
+then locally evaluate the configuration from the main branch and print the
+differences using the [`nix-diff`][nix-diff] tool. You should replace
+`<hostname>` with the appropriate hostname (eg. wpia-packit-dev).
+
+```sh
+nix run --refresh github:reside-ic/packit-infra#diff <hostname>
+```
+
+Depending on the changes that were made, the output of the command may be very
+verbose and contain lots of repetitive changes (eg. if base packages were
+updated).
+
+## Resolution
+
+Assuming there aren't any unexpected changes requiring special care, resolving
+the alert can be done by re-deploying the main branch to the machine (again
+replacing `<hostname>` as appropriate):
+
+```sh
+nix run --refresh github:reside-ic/packit-infra#deploy <hostname>
+```
+
+[prometheus]: https://bots.dide.ic.ac.uk/prometheus
+[packit-infra]: https://github.com/reside-ic/packit-infra
+[nix-diff]: https://github.com/Gabriella439/nix-diff
+[two-dots]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons


### PR DESCRIPTION
A link to these is included straight in the Slack notification. They include an overview of the alert's meaning and steps towards diagnosis and resolution of the issue.

We can add more playbooks for other alerts if and when they come up.