### PR TITLE
mrc-6701 Montagu packit config

### DIFF
--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -9,21 +9,21 @@ groups:
         annotations:
           error: "Montagu on {{ $labels.instance }} is down"
 
-  - name: montagu-packit
+  - name: packit-api
     rules:
-      - alert: MonatguPackitDown
-        expr: up{job="montagu-packit"} == 0
+      - alert: PackitAPIDown
+        expr: up{job="packit-api"} == 0
         for: 5m
         annotations:
-          error: "MontaguPackit on {{ $labels.instance }} is down"
+          error: "PackitAPI on {{ $labels.instance }} is down"
 
-  - name: montagu-outpack-server
+  - name: outpack-server
     rules:
-      - alert: MonatguOutpackServerDown
-        expr: up{job="montagu-outpack-server"} == 0
+      - alert: OutpackServerDown
+        expr: up{job="outpack-server"} == 0
         for: 5m
         annotations:
-          error: "MontaguOutpackServer on {{ $labels.instance }} is down"
+          error: "OutpackServer on {{ $labels.instance }} is down"
 
   - name: hint
     rules:

--- a/config/prometheus/blackbox-probes.yaml
+++ b/config/prometheus/blackbox-probes.yaml
@@ -29,7 +29,7 @@
     - https://science.montagu.dide.ic.ac.uk/packit/api
     - https://uat.montagu.dide.ic.ac.uk/packit/api
   labels:
-    project: montagu-packit
+    project: montagu-packit-api
 
 - targets:
   - https://mint.dide.ic.ac.uk

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -29,29 +29,24 @@ scrape_configs:
     static_configs:
       - targets: ['montagu.vaccineimpact.org:9113', 'uat.montagu.dide.ic.ac.uk:9113', 'science.montagu.dide.ic.ac.uk:9113']
     relabel_configs:
-      - source_labels: [__address__]
+      # Override the default instance name to remove the port
+      - source_labels: [ __address__ ]
+        regex: (.+):(.+)
         target_label: instance
-        regex: (uat)(.+)(9113)
-        replacement: 'UAT'
-      - source_labels: [__address__]
-        target_label: instance
-        regex: (science)(.+)(9113)
-        replacement: 'Science'
-      - source_labels: [__address__]
-        target_label: instance
-        regex: (.+)(vaccineimpact)(.+)
-        replacement: 'Production'
+        replacement: $1
 
-  - job_name: 'montagu-packit'
+  - job_name: 'packit-api'
     metrics_path: /metrics/packit-api
     scheme: http
     static_configs:
       - targets: ['montagu.vaccineimpact.org:9000', 'science.montagu.dide.ic.ac.uk:9000']
         labels:
           frequency: high
+          project: montagu
       - targets: ['uat.montagu.dide.ic.ac.uk:9000']
         labels:
           frequency: low
+          project: montagu
     relabel_configs:
       # Override the default instance name to remove the port
       - source_labels: [__address__]
@@ -59,7 +54,7 @@ scrape_configs:
         target_label: instance
         replacement: $1
 
-  - job_name: 'outpack_server'
+  - job_name: 'outpack-server'
     metrics_path: /metrics/outpack_server
     scheme: http
     static_configs:
@@ -70,18 +65,11 @@ scrape_configs:
         labels:
           frequency: low
     relabel_configs:
-      - source_labels: [__address__]
+      # Override the default instance name to remove the port
+      - source_labels: [ __address__ ]
+        regex: (.+):(.+)
         target_label: instance
-        regex: (uat)(.+)
-        replacement: 'UAT'
-      - source_labels: [__address__]
-        target_label: instance
-        regex: (science)(.+)
-        replacement: 'Science'
-      - source_labels: [__address__]
-        target_label: instance
-        regex: (.+)(vaccineimpact)(.+)
-        replacement: 'Production'
+        replacement: $1
 
   - job_name: 'hint'
     scheme: https
@@ -220,8 +208,6 @@ scrape_configs:
         target_label: __param_target
       - source_labels: [__param_target]
         target_label: instance
-        regex: ^(.*://)?(.*?)(:\d+)?$
-        replacement: $2
       - target_label: __address__
         replacement: blackbox-exporter:9115
 


### PR DESCRIPTION
Adds a blackbox probe for packit api, and also replaces the OrderlyWeb prometheus config with packit and outpack_server jobs. 

The new metrics endpoints are deployed on uat, so if you run the monitor locally you can see that the montagu-packit and montagu-outpack-server targets are up for uat. 

This shouldn't be deployed until montagu science and prod are redployed - which I may hold off doing until early next week!