### PR TITLE
Relax the AcmeBuddyCertificateNotLoaded alert.

### DIFF
--- a/config/prometheus/alert-rules.yml
+++ b/config/prometheus/alert-rules.yml
@@ -146,8 +146,7 @@ groups:
 
       - alert: AcmeBuddyCertificateNotLoaded
         expr: |
-          acme_buddy_certificate_info unless on(domain, fingerprint_sha256)
-            label_replace(probe_ssl_last_chain_info, "domain", "$1", "instance", "(.+)")
+          acme_buddy_certificate_info unless on(fingerprint_sha256) probe_ssl_last_chain_info
         for: 5m
         annotations:
           error: "certificate obtained by acme-buddy was not loaded: '{{ $labels.domain }}'"


### PR DESCRIPTION
The alert makes sure that every certificate obtained by acme-buddy has been loaded by the relevant http server.

We used to join on the instance/domain label, however a recent change to the configuration of the blackbox exporter means that the instance of `probe_ssl_last_chain_info` is now a full URL rather than just a domain name.

We could try to extract the domain name out of the URL to keep matching on it, but to be honest I don't believe that join criteria adds that much value. If the certificate had been loaded for a different domain name the blackbox exporter would fail TLS verification and the `probe_ssl_last_chain_info` metric would never show up. Removing that criteria is simpler.