### PR TITLE
Fix hostname of HPC VMs.

### DIFF
--- a/config/prometheus/linux-nodes.yaml
+++ b/config/prometheus/linux-nodes.yaml
@@ -55,7 +55,7 @@
   - wpia-vault.dide.ic.ac.uk
   - wpia-hiv-orderly.dide.ic.ac.uk
   - wpia-malaria-orderly.dide.ic.ac.uk
-  - wpia-modules.dide.ic.ac.uk
-  - wpia-hn2b.dide.ic.ac.uk
+  - wpia-modules.hpc.dide.ic.ac.uk
+  - wpia-hn2b.hpc.dide.ic.ac.uk
   - wpia-gpu-01.dide.ic.ac.uk
   - wpia-gpu-02.dide.ic.ac.uk


### PR DESCRIPTION
The VMs running on hn2 use the hpc.dide.ic.ac.uk. The hpc portion of that was missing.