### PR TITLE
Update grafana version

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ Connect as the `vagrant` user on `bots.dide.ic.ac.uk`, then
 
 ```
 # git clone --recursive https://github.com/vimc/montagu-monitor monitor
-cd ~/monitor
+cd ~/montagu-monitor
 git pull
 pip3 install --user -r requirements.txt
 ```
 
 And then either call `./run` (if there are code changes) or `./reload` (to
-refresh the config).
+refresh the config), or both (if both code changes and config changes).
 
 ## Metric exporters
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - '-interval=30s'
 
   grafana:
-    image: grafana/grafana-oss
+    image: grafana/grafana
     restart: unless-stopped
     ports:
       - '3000:3000'


### PR DESCRIPTION
The deployed version of Grafana is 11.3.0 from October 2024.

<img width="200" height="37" alt="image" src="https://github.com/user-attachments/assets/204f3522-e8ce-4397-a1ec-8473c78f0b3f" />

The latest available is 13.1.0 from June 2026. I wanted to update so we could have the latest UI for logs, matching my local experience of Grafana.

In docker-compose.yml, rather than pinning to that latest version, I just updated the image reference, because Grafana's [docs](https://grafana.com/docs/grafana/latest/setup-grafana/installation/docker/) say:

> Starting with Grafana release 12.4.0 , the grafana/grafana-oss Docker Hub repository will no longer be updated. Instead, we encourage you to use the grafana/grafana Docker Hub repository. These two repositories have the same Grafana OSS docker images.

After merging, I will run `./run` to re-deploy.

I have checked the documented breaking changes for the transition to [v12](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v12-0/#breaking-changes) and to [v13](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v13-0/#breaking-changes) and nothing seemed relevant to us. I have run this new image locally and it continued to work.