### PR TITLE
Pin Grafana to a version that does not cause a 'Plugin failed to load' error on Logs page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - '-interval=30s'
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:13.0.3
     restart: unless-stopped
     ports:
       - '3000:3000'


### PR DESCRIPTION
I was not able to determine why this error appeared on bots but not locally while using the same Grafana version (13.1.0):

```
Plugin failed to load
TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
at Lazy (<anonymous>) at h (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:308:9605) at i (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:2:807) at bo (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:305:72494) at i (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:289:69510) at s (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:2:594) at N (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:308:59596) at component (<anonymous>) at Suspense (<anonymous>) at l (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:14:169244) at dd (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:310:232557) at Cc (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:310:233342) at L (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:234:4593) at Qe (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:234:13787) at div (<anonymous>) at https://bots.dide.ic.ac.uk/grafana/public/build/5371-react19.f193a195fb5573093d22.js:1:131535 at main (<anonymous>) at div (<anonymous>) at div (<anonymous>) at div (<anonymous>) at Vp (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:310:341642) at ae (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:310:348863) at we (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:310:349999) at d (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:283:134993) at L (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:234:4593) at Qe (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:234:13787) at lt (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:234:13104) at mn (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:225:18290) at E (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:6:78918) at Sn (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:234:29887) at Fe (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:310:350262) at div (<anonymous>) at d (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:275:172265) at m (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:144:50938) at h (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:308:9605) at B (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:310:71546) at n (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:179:8955) at m (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:367:47416) at T (https://bots.dide.ic.ac.uk/grafana/public/build/8804-react19.d4bb3557f07af2a4656b.js:224:38407) at u (https://bots.dide.ic.ac.uk/grafana/public/build/5371-react19.f193a195fb5573093d22.js:24:4295) at te (https://bots.dide.ic.ac.uk/grafana/public/build/1591-react19.c8d5e532991b209273a0.js:275:127956) at l (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:14:169244) at https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:14:169899 at pt (https://bots.dide.ic.ac.uk/grafana/public/build/8804-react19.d4bb3557f07af2a4656b.js:228:512) at Zt (https://bots.dide.ic.ac.uk/grafana/public/build/841-react19.96d3bdb7faf562ee0bf4.js:310:350772)
```

However, pinning the bots version of grafana to 13.0.3 does not cause this issue, so it seems fine to pin to that working version.