### PR TITLE
Configure first logs alert

### DIFF
--- a/config/alertmanager.template.yml
+++ b/config/alertmanager.template.yml
@@ -21,6 +21,7 @@ route:
 templates:
   - 'templates/*.tmpl'
 
+# To receive alerts in a new slack channel, invite the app 'monitor' using the /invite command.
 receivers:
   - name: 'slack'
     slack_configs:

--- a/config/loki/alert-rules.yml
+++ b/config/loki/alert-rules.yml
@@ -8,9 +8,9 @@ groups:
     limit: 10
     rules:
       - alert: HighPercentageError
-        expr: |
+        expr: | # {container_name!=""} matches any stream with a container_name, only because we can't have an empty selector
           sum by (instance_hostname, container_name) (
-            rate({container_name!=""} |= "error" [5m])
+            rate({container_name!=""} |= "error" or "Error" or "ERROR" [5m])
           )
             /
           sum by (instance_hostname, container_name) (

--- a/config/loki/alert-rules.yml
+++ b/config/loki/alert-rules.yml
@@ -17,7 +17,7 @@ groups:
             rate({container_name!=""} [5m])
           )
             > 0.05
-        for: 2m
+        for: 5m
         annotations:
-          error: High percentage of error logs for 10 minutes for container "{{ $labels.container_name }}" on
+          error: High percentage of error logs for 5 minutes for container "{{ $labels.container_name }}" on
             host "{{ $labels.instance_hostname }}"

--- a/config/loki/alert-rules.yml
+++ b/config/loki/alert-rules.yml
@@ -1,0 +1,23 @@
+# This file configures:
+# - alerts on Loki, using Prometheus rules syntax: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+# - 'recording rules' for Loki, see https://grafana.com/docs/loki/latest/alert/#recording-rules
+
+groups:
+  - name: production_rules
+    interval: 1m # Query is executed every 1m
+    limit: 10
+    rules:
+      - alert: HighPercentageError
+        expr: |
+          sum by (instance_hostname, container_name) (
+            rate({container_name!=""} |= "error" [5m])
+          )
+            /
+          sum by (instance_hostname, container_name) (
+            rate({container_name!=""} [5m])
+          )
+            > 0.05
+        for: 2m
+        annotations:
+          error: High percentage of error logs for 10 minutes for container "{{ $labels.container_name }}" on
+            host "{{ $labels.instance_hostname }}"

--- a/config/loki/loki-config.yml
+++ b/config/loki/loki-config.yml
@@ -40,6 +40,14 @@ compactor:
   retention_enabled: true
   delete_request_store: filesystem
 
+ruler:
+  alertmanager_url: http://alertmanager:9093/alertmanager
+  storage:
+    type: local
+    local:
+      directory: /loki/rules # Directory to scan for rules
+  enable_api: true
+
 # The recommended limits_config values from https://grafana.com/docs/loki/latest/configure/bp-configure/#recommended-production-limits
 # NB These recommended values differ from the defaults at https://grafana.com/docs/loki/latest/configure/#limits_config
 limits_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     restart: always
     volumes:
       - ./config/loki/loki-config.yml:/etc/loki/config.yml:ro
+      - ./config/loki/alert-rules.yml:/loki/rules/fake/alert-rules.yml:ro # 'fake' is the default tenant name when auth_enabled is false
       - loki-storage:/loki
     command:
       # Debugging: Uncomment the line below to dump all config to logs including defaults.


### PR DESCRIPTION
Adds a rule to alert us when the rate of error log lines exceeds 5% of the rate of log lines, for a given container. We can adjust this is if it is too noisy or not noisy enough.

To test this in a local set-up, I ran a docker container that just outputted the word "error" interminably, and checked that the Slack channel monitor-dev alerted me to this. It did so.